### PR TITLE
New feature: Export skill tooltip

### DIFF
--- a/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
+++ b/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
@@ -1359,6 +1359,9 @@ namespace WzComparerR2.CharaSim
                 case 12005: return "카마도 탄지로";
                 case 12100: return "카마도 탄지로";
 
+                case 12006: return "사이타마";
+                case 12200: return "사이타마";
+
                 case 13000: return "핑크빈";
                 case 13001: return "예티";
                 case 13100: return "핑크빈";
@@ -1479,11 +1482,11 @@ namespace WzComparerR2.CharaSim
                 case 18211: return "시아 아스텔(3차)";
                 case 18212: return "시아 아스텔(4차)";
                 case 18214: return "시아 아스텔(6차)";
-                case 18300: return "샤인_궁수(1차)";
-                case 18310: return "샤인_궁수(2차)";
-                case 18311: return "샤인_궁수(3차)";
-                case 18312: return "샤인_궁수(4차)";
-                case 18314: return "샤인_궁수(6차)";
+                case 18300: return "아이엘(1차)";
+                case 18310: return "아이엘(2차)";
+                case 18311: return "아이엘(3차)";
+                case 18312: return "아이엘(4차)";
+                case 18314: return "아이엘(6차)";
                 case 18400: return "샤인_도적(1차)";
                 case 18410: return "샤인_도적(2차)";
                 case 18411: return "샤인_도적(3차)";
@@ -1494,7 +1497,7 @@ namespace WzComparerR2.CharaSim
                 case 18511: return "샤인_해적(3차)";
                 case 18512: return "샤인_해적(4차)";
                 case 18514: return "샤인_해적(6차)";
-                
+
 
                 case 40000: return "5차";
                 case 40001: return "5차(전사)";
@@ -1509,6 +1512,65 @@ namespace WzComparerR2.CharaSim
                 case 50007: return "6차(헥사스탯)";
             }
             return null;
+        }
+        
+        public static string GetFifthJobName(int skillCode, List<int> jobId)
+        {
+            string jobName = "";
+            switch (jobId.Count)
+            {
+                case 0:
+                    jobName = GetJobName(skillCode / 10000);
+                    break;
+                case 1:
+                    if (jobId[0] == 0)
+                    {
+                        jobName = GetJobName(skillCode / 10000);
+                    }
+                    else
+                    {
+                        jobName = GetJobName(jobId[0]);
+                        jobName = jobName.Contains("(4") ? jobName.Replace("(4", "(5") : jobName + "(5차)";
+                    }
+                    break;
+                default:
+                    bool isSameFaction = true;
+                    int faction = jobId[0] / 1000;
+                    if (faction == 5) faction = 1;
+                    foreach (int id in jobId.Skip(1))
+                    {
+                        if (id == 0) continue;
+                        isSameFaction = isSameFaction && (id / 1000 == faction);
+                    }
+                    if (isSameFaction)
+                    {
+                        switch (faction)
+                        {
+                            case 0: jobName = "5차(모험자)"; break; 
+                            case 1: 
+                            case 5: jobName = "5차(시그너스 기사단)"; break; 
+                            case 2: jobName = "5차(영웅)"; break; 
+                            case 3: jobName = "5차(레지스턴스)"; break; 
+                            case 4: jobName = "5차(새벽의 진)"; break; 
+                            case 6: jobName = "5차(노바)"; break; 
+                            case 10: jobName = "5차(초월자)"; break; 
+                            case 11: jobName = "5차(던베일)"; break; 
+                            // case 12: jobName = "5차(애니메이션 콜라보레이션)"; break; 
+                            case 13: jobName = "5차(몬스터)"; break; 
+                            case 14: jobName = "5차(프렌드 월드)"; break; 
+                            case 15: jobName = "5차(레프)"; break; 
+                            case 16: jobName = "5차(애니마)"; break; 
+                            case 17: jobName = "5차(강호)"; break; 
+                            case 18: jobName = "5차(샤인)"; break;
+                        }
+                    }
+                    else
+                    {
+                        jobName = GetJobName(skillCode / 10000);
+                    }
+                    break;
+            }
+            return jobName;
         }
 
         public static string ToChineseNumberExpr(long value)

--- a/WzComparerR2/FrmSkillTooltipExport.Designer.cs
+++ b/WzComparerR2/FrmSkillTooltipExport.Designer.cs
@@ -1,0 +1,139 @@
+﻿namespace WzComparerR2
+{
+    partial class FrmSkillTooltipExport
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblSelectJobIntro = new DevComponents.DotNetBar.LabelX();
+            this.clbJobName = new System.Windows.Forms.CheckedListBox();
+            this.btnSort = new DevComponents.DotNetBar.ButtonX();
+            this.btnSelectAll = new DevComponents.DotNetBar.ButtonX();
+            this.btnReverseSelect = new DevComponents.DotNetBar.ButtonX();
+            this.btnExport = new DevComponents.DotNetBar.ButtonX();
+            this.SuspendLayout();
+            // 
+            // lblSelectJobIntro
+            // 
+            this.lblSelectJobIntro.AutoSize = true;
+            // 
+            // 
+            // 
+            this.lblSelectJobIntro.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.lblSelectJobIntro.Location = new System.Drawing.Point(10, 7);
+            this.lblSelectJobIntro.Name = "lblSelectJobIntro";
+            this.lblSelectJobIntro.Size = new System.Drawing.Size(222, 16);
+            this.lblSelectJobIntro.TabIndex = 0;
+            this.lblSelectJobIntro.Text = "내보낼 직업을 선택합니다.";
+            // 
+            // clbJobName
+            // 
+            this.clbJobName.FormattingEnabled = true;
+            this.clbJobName.Location = new System.Drawing.Point(10, 30);
+            this.clbJobName.Name = "clbJobName";
+            this.clbJobName.Font = new System.Drawing.Font("Dotum", 12F);
+            this.clbJobName.Size = new System.Drawing.Size(430, 522);
+            this.clbJobName.TabIndex = 1;
+            // 
+            // btnSort
+            // 
+            this.btnSort.Location = new System.Drawing.Point(339, 5);
+            this.btnSort.Name = "btnSort";
+            this.btnSort.Size = new System.Drawing.Size(100, 20);
+            this.btnSort.TabIndex = 2;
+            this.btnSort.Text = "초기 주문";
+            this.btnSort.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnSort.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnSort.Click += new System.EventHandler(this.btnSort_Click);
+            // 
+            // 
+            // btnSelectAll
+            // 
+            this.btnSelectAll.Location = new System.Drawing.Point(10, 550);
+            this.btnSelectAll.Name = "btnSelectAll";
+            this.btnSelectAll.Size = new System.Drawing.Size(100, 35);
+            this.btnSelectAll.TabIndex = 3;
+            this.btnSelectAll.Text = "모두 선택";
+            this.btnSelectAll.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnSelectAll.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnSelectAll.Click += new System.EventHandler(this.btnSelectAll_Click);
+            // 
+            // btnReverseSelect
+            // 
+            this.btnReverseSelect.Location = new System.Drawing.Point(174, 550);
+            this.btnReverseSelect.Name = "btnReverseSelect";
+            this.btnReverseSelect.Size = new System.Drawing.Size(100, 35);
+            this.btnReverseSelect.TabIndex = 4;
+            this.btnReverseSelect.Text = "역 선택";
+            this.btnReverseSelect.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnReverseSelect.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnReverseSelect.Click += new System.EventHandler(this.btnReverseSelect_Click);
+            // 
+            // btnExport
+            // 
+            this.btnExport.Location = new System.Drawing.Point(338, 550);
+            this.btnExport.Name = "btnExport";
+            this.btnExport.Size = new System.Drawing.Size(100, 35);
+            this.btnExport.TabIndex = 5;
+            this.btnExport.Text = "내보내기";
+            this.btnExport.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnExport.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnExport.Click += new System.EventHandler(this.btnExport_Click);
+            // 
+            // FrmSkillTooltipExport
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(450, 600);
+            this.Controls.Add(this.btnExport);
+            this.Controls.Add(this.btnReverseSelect);
+            this.Controls.Add(this.btnSelectAll);
+            this.Controls.Add(this.btnSort);
+            this.Controls.Add(this.clbJobName);
+            this.Controls.Add(this.lblSelectJobIntro);
+            this.DoubleBuffered = true;
+            this.Font = new System.Drawing.Font("굴림", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "FrmSkillTooltipExport";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "스킬 툴팁 내보내기";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        
+        private DevComponents.DotNetBar.LabelX lblSelectJobIntro;
+        private System.Windows.Forms.CheckedListBox clbJobName;
+        private DevComponents.DotNetBar.ButtonX btnSort;
+        private DevComponents.DotNetBar.ButtonX btnSelectAll;
+        private DevComponents.DotNetBar.ButtonX btnReverseSelect;
+        private DevComponents.DotNetBar.ButtonX btnExport;
+    }
+}

--- a/WzComparerR2/FrmSkillTooltipExport.cs
+++ b/WzComparerR2/FrmSkillTooltipExport.cs
@@ -1,0 +1,254 @@
+﻿using DevComponents.DotNetBar;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using WzComparerR2.WzLib;
+
+namespace WzComparerR2
+{
+    public partial class FrmSkillTooltipExport : DevComponents.DotNetBar.Office2007Form
+    {
+        public FrmSkillTooltipExport()
+        {
+            InitializeComponent();
+#if NET6_0_OR_GREATER
+            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#controldefaultfont-changed-to-segoe-ui-9pt
+            this.Font = new Font("굴림", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+#endif
+            this.clbJobName.Items.Add("기타", false);
+            foreach (var i in jobNameToCode.Keys)
+            {
+                this.clbJobName.Items.Add(i, false);
+            }
+        }
+
+        public string ExportFolderPath { get; private set; }
+        public List<int> SelectedJobCodes { get; private set; }
+        public Wz_Node skillNode { get; set; }
+        private bool sorted = false;
+
+        private static Dictionary<string, int[]> jobNameToCode = new Dictionary<string, int[]>()
+        {
+            { "히어로", new int[] { 100, 110, 111, 112, 114 } }, 
+            { "팔라딘", new int[] { 100, 120, 121, 122, 124 } }, 
+            { "다크나이트", new int[] { 100, 130, 131, 132, 134 } }, 
+            { "아크메이지(불,독)", new int[] { 200, 210, 211, 212, 214 } }, 
+            { "아크메이지(썬,콜)", new int[] { 200, 220, 221, 222, 224 } }, 
+            { "비숍", new int[] { 200, 230, 231, 232, 234 } }, 
+            { "보우마스터", new int[] { 300, 310, 311, 312, 314 } }, 
+            { "신궁", new int[] { 300, 320, 321, 322, 324 } }, 
+            { "패스파인더", new int[] { 301, 330, 331, 332, 334 } }, 
+            { "나이트로드", new int[] { 400, 410, 411, 412, 414 } }, 
+            { "섀도어", new int[] { 400, 420, 421, 422, 424 } }, 
+            { "듀얼블레이더", new int[] { 400, 430, 431, 432, 433, 434, 436 } }, 
+            { "바이퍼", new int[] { 500, 510, 511, 512, 514 } }, 
+            { "캡틴", new int[] { 500, 520, 521, 522, 524 } }, 
+            { "캐논마스터", new int[] { 501, 530, 531, 532, 534 } }, 
+            // { "용의 전인 && 제트", new int[] { 508, 570, 571, 572, 574 } }, 
+            { "소울마스터", new int[] { 1000, 1100, 1110, 1111, 1112, 1114 } }, 
+            { "플레임위자드", new int[] { 1000, 1200, 1210, 1211, 1212, 1214 } }, 
+            { "윈드브레이커", new int[] { 1000, 1300, 1310, 1311, 1312, 1314 } }, 
+            { "나이트워커", new int[] { 1000, 1400, 1410, 1411, 1412, 1414 } }, 
+            { "스트라이커", new int[] { 1000, 1500, 1510, 1511, 1512, 1514 } }, 
+            { "아란", new int[] { 2000, 2100, 2110, 2111, 2112, 2114 } }, 
+            { "에반", new int[] { 2001, 2200, 2210, 2211, 2212, 2213, 2214, 2215, 2216, 2217, 2218, 2219, 2220 } }, 
+            { "메르세데스", new int[] { 2002, 2300, 2310, 2311, 2312, 2314 } }, 
+            { "팬텀", new int[] { 2003, 2400, 2410, 2411, 2412, 2414 } }, 
+            { "루미너스", new int[] { 2004, 2700, 2710, 2711, 2712, 2714 } }, 
+            { "은월", new int[] { 2005, 2500, 2510, 2511, 2512, 2514 } }, 
+            { "데몬 슬레이어", new int[] { 3001, 3100, 3110, 3111, 3112, 3114 } }, 
+            { "데몬 어벤져", new int[] { 3001, 3101, 3120, 3121, 3122, 3124 } }, 
+            { "블래스터", new int[] { 3000, 3700, 3710, 3711, 3712, 3714 } }, 
+            { "배틀메이지", new int[] { 3000, 3200, 3210, 3211, 3212, 3214 } }, 
+            { "와일드헌터", new int[] { 3000, 3300, 3310, 3311, 3312, 3314 } }, 
+            { "메카닉", new int[] { 3000, 3500, 3510, 3511, 3512, 3514 } }, 
+            { "제논", new int[] { 3002, 3600, 3610, 3611, 3612, 3614 } }, 
+            { "하야토", new int[] { 4001, 4100, 4110, 4111, 4112, 4114 } }, 
+            { "칸나", new int[] { 4002, 4200, 4210, 4211, 4212, 4214 } }, 
+            { "미하일", new int[] { 5000, 5100, 5110, 5111, 5112, 5114 } }, 
+            { "카이저", new int[] { 6000, 6100, 6110, 6111, 6112, 6114 } }, 
+            { "카인", new int[] { 6003, 6300, 6310, 6311, 6312, 6314 } }, 
+            { "카데나", new int[] { 6002, 6400, 6410, 6411, 6412, 6414 } }, 
+            { "엔젤릭버스터", new int[] { 6001, 6500, 6510, 6511, 6512, 6514 } }, 
+            // { "어빌리티", new int[] { 7000 } }, 
+            // { "유니온", new int[] { 7100 } }, 
+            // { "몬스터라이프", new int[] { 7200 } }, 
+            // { "길드", new int[] { 9100 } }, 
+            // { "전업기술", new int[] { 9200, 9201, 9202, 9203, 9204 } }, 
+            { "제로", new int[] { 10000, 10100, 10110, 10111, 10112, 10114 } }, 
+            // { "비스트테이머", new int[] { 11000, 11200, 11210, 11211, 11212 } }, 
+            { "카마도 탄지로", new int[] { 12000, 12005, 12100 } }, 
+            { "사이타마", new int[] { 12006, 12200 } }, 
+            { "핑크빈", new int[] { 13000, 13100 } }, 
+            { "예티", new int[] { 13001, 13500 } }, 
+            { "키네시스", new int[] { 14000, 14200, 14210, 14211, 14212, 14214 } }, 
+            { "아델", new int[] { 15002, 15100, 15110, 15111, 15112, 15114 } }, 
+            { "일리움", new int[] { 15000, 15200, 15210, 15211, 15212, 15214 } }, 
+            { "칼리", new int[] { 15003, 15400, 15410, 15411, 15412, 15414 } }, 
+            { "아크", new int[] { 15001, 15500, 15510, 15511, 15512, 15514 } }, 
+            { "렌", new int[] { 16002, 16100, 16110, 16111, 16112, 16114 } }, 
+            { "라라", new int[] { 16001, 16200, 16210, 16211, 16212, 16214 } }, 
+            { "호영", new int[] { 16000, 16400, 16410, 16411, 16412, 16414 } }, 
+            { "묵현", new int[] { 17000, 17500, 17510, 17511, 17512, 17514 } }, 
+            { "린", new int[] { 17001, 17200, 17210, 17211, 17212, 17214 } }, 
+            // { "에릴 라이트", new int[] { 18001, 18100, 18110, 18111, 18112, 18114 } }, 
+            { "시아 아스텔", new int[] { 18000, 18200, 18210, 18211, 18212, 18214 } }, 
+            // { "아이엘", new int[] { 18002, 18300, 18310, 18311, 18312, 18314 } }, 
+            { "5차(기타)", new int[] { 40000, 40001, 40002, 40003, 40004, 40005 } }, 
+            { "6차(기타)", new int[] { 50000, 50006, 50007 } },
+        };
+
+        private static Dictionary<string, int[]> jobNameToCodeSorted = new Dictionary<string, int[]>()
+        {
+            // { "길드", new int[] { 9100 } }, 
+            { "나이트로드", new int[] { 400, 410, 411, 412, 414 } }, 
+            { "나이트워커", new int[] { 1000, 1400, 1410, 1411, 1412, 1414 } }, 
+            { "다크나이트", new int[] { 100, 130, 131, 132, 134 } }, 
+            { "데몬 슬레이어", new int[] { 3001, 3100, 3110, 3111, 3112, 3114 } }, 
+            { "데몬 어벤져", new int[] { 3001, 3101, 3120, 3121, 3122, 3124 } }, 
+            { "듀얼블레이더", new int[] { 400, 430, 431, 432, 433, 434, 436 } }, 
+            { "라라", new int[] { 16001, 16200, 16210, 16211, 16212, 16214 } }, 
+            { "렌", new int[] { 16002, 16100, 16110, 16111, 16112, 16114 } }, 
+            { "루미너스", new int[] { 2004, 2700, 2710, 2711, 2712, 2714 } }, 
+            { "린", new int[] { 17001, 17200, 17210, 17211, 17212, 17214 } }, 
+            { "메르세데스", new int[] { 2002, 2300, 2310, 2311, 2312, 2314 } }, 
+            { "메카닉", new int[] { 3000, 3500, 3510, 3511, 3512, 3514 } }, 
+            // { "몬스터라이프", new int[] { 7200 } }, 
+            { "묵현", new int[] { 17000, 17500, 17510, 17511, 17512, 17514 } }, 
+            { "미하일", new int[] { 5000, 5100, 5110, 5111, 5112, 5114 } }, 
+            { "바이퍼", new int[] { 500, 510, 511, 512, 514 } }, 
+            { "배틀메이지", new int[] { 3000, 3200, 3210, 3211, 3212, 3214 } }, 
+            { "보우마스터", new int[] { 300, 310, 311, 312, 314 } }, 
+            { "블래스터", new int[] { 3000, 3700, 3710, 3711, 3712, 3714 } }, 
+            { "비숍", new int[] { 200, 230, 231, 232, 234 } }, 
+            // { "비스트테이머", new int[] { 11000, 11200, 11210, 11211, 11212 } }, 
+            { "사이타마", new int[] { 12006, 12200 } }, 
+            { "섀도어", new int[] { 400, 420, 421, 422, 424 } }, 
+            { "소울마스터", new int[] { 1000, 1100, 1110, 1111, 1112, 1114 } }, 
+            { "스트라이커", new int[] { 1000, 1500, 1510, 1511, 1512, 1514 } }, 
+            { "시아 아스텔", new int[] { 18000, 18200, 18210, 18211, 18212, 18214 } }, 
+            { "신궁", new int[] { 300, 320, 321, 322, 324 } }, 
+            { "아델", new int[] { 15002, 15100, 15110, 15111, 15112, 15114 } }, 
+            { "아란", new int[] { 2000, 2100, 2110, 2111, 2112, 2114 } }, 
+            // { "아이엘", new int[] { 18002, 18300, 18310, 18311, 18312, 18314 } }, 
+            { "아크", new int[] { 15001, 15500, 15510, 15511, 15512, 15514 } }, 
+            { "아크메이지(불,독)", new int[] { 200, 210, 211, 212, 214 } }, 
+            { "아크메이지(썬,콜)", new int[] { 200, 220, 221, 222, 224 } }, 
+            // { "어빌리티", new int[] { 7000 } }, 
+            // { "에릴 라이트", new int[] { 18001, 18100, 18110, 18111, 18112, 18114 } }, 
+            { "에반", new int[] { 2001, 2200, 2210, 2211, 2212, 2213, 2214, 2215, 2216, 2217, 2218, 2219, 2220 } }, 
+            { "엔젤릭버스터", new int[] { 6001, 6500, 6510, 6511, 6512, 6514 } }, 
+            { "예티", new int[] { 13001, 13500 } }, 
+            { "와일드헌터", new int[] { 3000, 3300, 3310, 3311, 3312, 3314 } }, 
+            { "윈드브레이커", new int[] { 1000, 1300, 1310, 1311, 1312, 1314 } }, 
+            // { "유니온", new int[] { 7100 } }, 
+            { "은월", new int[] { 2005, 2500, 2510, 2511, 2512, 2514 } }, 
+            { "일리움", new int[] { 15000, 15200, 15210, 15211, 15212, 15214 } }, 
+            // { "전업기술", new int[] { 9200, 9201, 9202, 9203, 9204 } }, 
+            { "제논", new int[] { 3002, 3600, 3610, 3611, 3612, 3614 } }, 
+            { "제로", new int[] { 10000, 10100, 10110, 10111, 10112, 10114 } }, 
+            // { "용의 전인 & 제트", new int[] { 508, 570, 571, 572, 574 } }, 
+            { "카데나", new int[] { 6002, 6400, 6410, 6411, 6412, 6414 } }, 
+            { "카마도 탄지로", new int[] { 12000, 12005, 12100 } }, 
+            { "카이저", new int[] { 6000, 6100, 6110, 6111, 6112, 6114 } }, 
+            { "카인", new int[] { 6003, 6300, 6310, 6311, 6312, 6314 } }, 
+            { "칸나", new int[] { 4002, 4200, 4210, 4211, 4212, 4214 } }, 
+            { "칼리", new int[] { 15003, 15400, 15410, 15411, 15412, 15414 } }, 
+            { "캐논마스터", new int[] { 501, 530, 531, 532, 534 } }, 
+            { "캡틴", new int[] { 500, 520, 521, 522, 524 } }, 
+            { "키네시스", new int[] { 14000, 14200, 14210, 14211, 14212, 14214 } }, 
+            { "팔라딘", new int[] { 100, 120, 121, 122, 124 } }, 
+            { "패스파인더", new int[] { 301, 330, 331, 332, 334 } }, 
+            { "팬텀", new int[] { 2003, 2400, 2410, 2411, 2412, 2414 } }, 
+            { "플레임위자드", new int[] { 1000, 1200, 1210, 1211, 1212, 1214 } }, 
+            { "핑크빈", new int[] { 13000, 13100 } }, 
+            { "하야토", new int[] { 4001, 4100, 4110, 4111, 4112, 4114 } }, 
+            { "호영", new int[] { 16000, 16400, 16410, 16411, 16412, 16414 } }, 
+            { "히어로", new int[] { 100, 110, 111, 112, 114 } }, 
+            { "5차(기타)", new int[] { 40000, 40001, 40002, 40003, 40004, 40005 } }, 
+            { "6차(기타)", new int[] { 50000, 50006, 50007 } },
+        };
+
+        private static HashSet<int> AllClassesCode()
+        {
+            HashSet<int> hsClassCode = new HashSet<int>() { };
+            foreach (var i in jobNameToCode.Values)
+            {
+                foreach (var j in i)
+                {
+                    hsClassCode.Add(j);
+                }
+            }
+            return hsClassCode;
+        }
+
+        private void btnSort_Click(object sender, EventArgs e)
+        {
+            this.sorted = !this.sorted;
+            this.btnSort.Text = this.sorted ? "한글 알파벳 순서" : "초기 주문";
+            this.clbJobName.Items.Clear();
+            this.clbJobName.Items.Add("기타", this.clbJobName.CheckedItems.Contains("기타"));
+            var sourceDict = this.sorted ? jobNameToCodeSorted : jobNameToCode;
+            foreach (var i in sourceDict.Keys)
+            {
+                this.clbJobName.Items.Add(i, this.clbJobName.CheckedItems.Contains(i));
+            }
+        }
+
+        private void btnSelectAll_Click(object sender, EventArgs e)
+        {
+            int checkedCount = this.clbJobName.CheckedItems.Contains("기타") ? this.clbJobName.CheckedItems.Count - 1 : this.clbJobName.CheckedItems.Count;
+            bool checkedStatus = (checkedCount < this.clbJobName.Items.Count - 1);
+            for (int i = 1; i < this.clbJobName.Items.Count; i++)
+            {
+                this.clbJobName.SetItemChecked(i, checkedStatus);
+            }
+        }
+
+        private void btnReverseSelect_Click(object sender, EventArgs e)
+        {
+            for (int i = 1; i < this.clbJobName.Items.Count; i++)
+            {
+                this.clbJobName.SetItemChecked(i, !this.clbJobName.GetItemChecked(i));
+            }
+        }
+
+        private void btnExport_Click(object sender, EventArgs e)
+        {
+            if (this.clbJobName.CheckedItems.Count == 0)
+            {
+                MessageBoxEx.Show("내보낼 직업을 하나 이상 선택합니다.", "직업 미선택", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            FolderBrowserDialog dlg = new FolderBrowserDialog();
+            dlg.Description = "저장할 폴더를 선택하세요.";
+
+            if (dlg.ShowDialog() == DialogResult.OK)
+            {
+                bool allSelected = this.clbJobName.CheckedItems.Count == this.clbJobName.Items.Count;
+
+                List<int> skillImg = new List<int>() { };
+                foreach (Wz_Node node in skillNode.Nodes)
+                {
+                    Wz_Image currentImg = node.GetValue<Wz_Image>();
+                    if (currentImg != null && Int32.TryParse(currentImg.Name.Replace(".img", ""), out int jobCode))
+                    {
+                        skillImg.Add(jobCode);
+                    }
+                }
+                List<int> selectedJob = skillImg.Intersect(this.clbJobName.CheckedItems.Cast<string>().SelectMany(name => jobNameToCode.ContainsKey(name) ? jobNameToCode[name] : new int[] { }).ToList()).ToList();
+                if (this.clbJobName.CheckedItems.Contains("기타"))
+                {
+                    selectedJob.AddRange(skillImg.Except(AllClassesCode()));
+                }
+                ExportFolderPath = dlg.SelectedPath;
+                SelectedJobCodes = allSelected ? skillImg : selectedJob;
+                this.DialogResult = DialogResult.OK;
+            }
+        }
+    }
+}

--- a/WzComparerR2/FrmSkillTooltipExport.resx
+++ b/WzComparerR2/FrmSkillTooltipExport.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="lblSelectJobIntro.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/WzComparerR2/MainForm.Designer.cs
+++ b/WzComparerR2/MainForm.Designer.cs
@@ -229,6 +229,7 @@
             this.chkOutputRemovedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkOutputAddedImg = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.labelX1 = new DevComponents.DotNetBar.LabelX();
+            this.labelX2 = new DevComponents.DotNetBar.LabelX();
             this.chkOutputPng = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.cmbComparePng = new DevComponents.DotNetBar.Controls.ComboBoxEx();
             this.labelXComp2 = new DevComponents.DotNetBar.LabelX();
@@ -286,6 +287,7 @@
             this.comboItem19 = new DevComponents.Editors.ComboItem();
             this.btnRootNode = new DevComponents.DotNetBar.ButtonX();
             this.clbRootNode = new System.Windows.Forms.CheckedListBox();
+            this.btnSkillTooltipExport = new DevComponents.DotNetBar.ButtonX();
             this.ribbonControl1.SuspendLayout();
             this.ribbonPanel1.SuspendLayout();
             this.ribbonPanel2.SuspendLayout();
@@ -2811,8 +2813,10 @@
             // 
             // superTabControlPanel3
             // 
+            this.superTabControlPanel3.Controls.Add(this.btnSkillTooltipExport);
             this.superTabControlPanel3.Controls.Add(this.btnExportSkillOption);
             this.superTabControlPanel3.Controls.Add(this.btnExportSkill);
+            this.superTabControlPanel3.Controls.Add(this.labelX2);
             this.superTabControlPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.superTabControlPanel3.Location = new System.Drawing.Point(0, 0);
             this.superTabControlPanel3.Name = "superTabControlPanel3";
@@ -2820,13 +2824,25 @@
             this.superTabControlPanel3.TabIndex = 0;
             this.superTabControlPanel3.TabItem = this.superTabItem3;
             // 
+            // btnSkillTooltipExport
+            // 
+            this.btnSkillTooltipExport.AccessibleRole = System.Windows.Forms.AccessibleRole.PushButton;
+            this.btnSkillTooltipExport.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
+            this.btnSkillTooltipExport.Location = new System.Drawing.Point(233, 6);
+            this.btnSkillTooltipExport.Name = "btnSkillTooltipExport";
+            this.btnSkillTooltipExport.Size = new System.Drawing.Size(115, 23);
+            this.btnSkillTooltipExport.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.btnSkillTooltipExport.TabIndex = 2;
+            this.btnSkillTooltipExport.Text = "스킬 툴팁 내보내기";
+            this.btnSkillTooltipExport.Click += new System.EventHandler(this.btnSkillTooltipExport_Click);
+            // 
             // btnExportSkillOption
             // 
             this.btnExportSkillOption.AccessibleRole = System.Windows.Forms.AccessibleRole.PushButton;
             this.btnExportSkillOption.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
-            this.btnExportSkillOption.Location = new System.Drawing.Point(99, 6);
+            this.btnExportSkillOption.Location = new System.Drawing.Point(104, 6);
             this.btnExportSkillOption.Name = "btnExportSkillOption";
-            this.btnExportSkillOption.Size = new System.Drawing.Size(111, 23);
+            this.btnExportSkillOption.Size = new System.Drawing.Size(115, 23);
             this.btnExportSkillOption.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.btnExportSkillOption.TabIndex = 1;
             this.btnExportSkillOption.Text = "스킬 옵션 내보내기";
@@ -2838,11 +2854,25 @@
             this.btnExportSkill.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground;
             this.btnExportSkill.Location = new System.Drawing.Point(6, 6);
             this.btnExportSkill.Name = "btnExportSkill";
-            this.btnExportSkill.Size = new System.Drawing.Size(75, 23);
+            this.btnExportSkill.Size = new System.Drawing.Size(84, 23);
             this.btnExportSkill.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.btnExportSkill.TabIndex = 0;
             this.btnExportSkill.Text = "스킬 내보내기";
             this.btnExportSkill.Click += new System.EventHandler(this.btnExportSkill_Click);
+
+            // 
+            // labelX2
+            // 
+            this.labelX2.AutoSize = true;
+            // 
+            // 
+            // 
+            this.labelX2.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.labelX2.Location = new System.Drawing.Point(24, 39);
+            this.labelX2.Name = "labelX2";
+            this.labelX2.Size = new System.Drawing.Size(44, 16);
+            this.labelX2.TabIndex = 2;
+            this.labelX2.Text = "";
             // 
             // superTabItem3
             // 
@@ -3561,6 +3591,7 @@
         private DevComponents.DotNetBar.ButtonX btnExportSkillOption;
         private DevComponents.DotNetBar.ButtonX btnExportSkill;
         private DevComponents.DotNetBar.LabelX labelX1;
+        private DevComponents.DotNetBar.LabelX labelX2;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkOutputPng;
         private DevComponents.DotNetBar.Controls.ComboBoxEx cmbComparePng;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkOutputRemovedImg;
@@ -3621,5 +3652,6 @@
         private DevComponents.DotNetBar.ColorPickerDropDown colorPickerPicBoxBgColor;
         private DevComponents.DotNetBar.ButtonX btnRootNode;
         private System.Windows.Forms.CheckedListBox clbRootNode;
+        private DevComponents.DotNetBar.ButtonX btnSkillTooltipExport;
     }
 }

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -4175,6 +4175,184 @@ namespace WzComparerR2
             }
         }
 
+        private async void btnSkillTooltipExport_Click(object sender, EventArgs e)
+        {
+            if (PluginManager.FindWz(Wz_Type.Base) == null)
+            {
+                ToastNotification.Show(this, $"오류: Base.wz를 먼저 열어주세요.", null, 2000, eToastGlowColor.Red, eToastPosition.TopCenter);
+                return;
+            }
+            if (openedWz.Count > 1)
+            {
+                ToastNotification.Show(this, $"오류: 이 기능을 사용하기 전에 Base.wz를 하나만 여십시오.", null, 4000, eToastGlowColor.Red, eToastPosition.TopCenter);
+                return;
+            }
+            using (FrmSkillTooltipExport frm = new FrmSkillTooltipExport())
+            {
+                frm.skillNode = PluginManager.FindWz(Wz_Type.Skill);
+                if (frm.ShowDialog() == DialogResult.OK)
+                {
+                    var Setting = CharaSimConfig.Default;
+                    List<int> selectedJob = frm.SelectedJobCodes;
+                    string exportedFolder = frm.ExportFolderPath;
+                    labelX2.Text = "내보내는 중";
+                    System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
+                    try
+                    {
+                        sw.Start();
+                        btnSkillTooltipExport.Enabled = false;
+                        await Task.Run(() =>
+                        {
+                            if (!this.stringLinker.HasValues)
+                                this.stringLinker.Load(findStringWz(), findItemWz(), findEtcWz(), findQuestWz());
+
+                            // Initialize VCore Dictionary
+                            Dictionary<int, List<int>> FifthJobSkillToJobID = new Dictionary<int, List<int>>();
+                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                            if (vCoreData != null)
+                            {
+                                foreach (Wz_Node data in vCoreData.Nodes)
+                                {
+                                    Wz_Node connectSkill = data.FindNodeByPath("connectSkill").ResolveUol();
+                                    Wz_Node jobIDValue = data.FindNodeByPath("job").ResolveUol();
+                                    List<int> applicableJobID = new List<int>();
+                                    foreach (Wz_Node jobID in jobIDValue.Nodes)
+                                    {
+                                        applicableJobID.Add(jobID.GetValueEx<int>(0));
+                                    }
+                                    if (connectSkill == null)
+                                    {
+                                        int skillIDValue = data.FindNodeByPath("spCoreOption\\effect\\skill_id").ResolveUol().GetValueEx<int>(0);
+                                        if (!FifthJobSkillToJobID.ContainsKey(skillIDValue)) FifthJobSkillToJobID.Add(skillIDValue, [0]);
+                                    }
+                                    else
+                                    {
+                                        foreach (Wz_Node skillID in connectSkill.Nodes)
+                                        {
+                                            int skillIDValue = skillID.GetValueEx<int>(0);
+                                            if (skillIDValue > 0 && !FifthJobSkillToJobID.ContainsKey(skillIDValue))
+                                            {
+                                                FifthJobSkillToJobID.Add(skillIDValue, applicableJobID);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            SkillTooltipRender2 tooltip = new SkillTooltipRender2();
+                            tooltip.StringLinker = this.stringLinker;
+                            tooltip.ShowObjectID = Setting.Skill.ShowID;
+                            tooltip.ShowDelay = Setting.Skill.ShowDelay;
+                            tooltip.IgnoreEvalError = Setting.Skill.IgnoreEvalError;
+                            tooltip.Enable22AniStyle = Setting.Misc.Enable22AniStyle;
+                            foreach (var i in selectedJob)
+                            {
+                                var jobImg = PluginManager.FindWz($"Skill\\{i:D3}.img\\skill", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                if (jobImg == null)
+                                {
+                                    continue;
+                                }
+                                foreach (var j in jobImg.Nodes)
+                                {
+                                    StringResult sr;
+                                    string skillName;
+                                    if (tooltip.StringLinker == null || !tooltip.StringLinker.StringSkill.TryGetValue(int.Parse(j.Text), out sr))
+                                    {
+                                        sr = new StringResultSkill();
+                                        sr.Name = "알 수없는 스킬";
+                                    }
+                                    skillName = sr.Name;
+                                    labelX2.Text = string.Format("내보내는 중: {0} - {1}", j.Text, skillName);
+                                    Skill skill = Skill.CreateFromNode(j, PluginManager.FindWz, PluginManager.FindWz);
+                                    if (skill != null)
+                                    {
+                                        skill.Level = skill.MaxLevel;
+                                        tooltip.Skill = skill;
+                                    }
+                                    else
+                                    {
+                                        continue;
+                                    }
+                                    Bitmap resultImage = tooltip.Render();
+                                    string categoryPath = "";
+                                    if (FifthJobSkillToJobID.ContainsKey(int.Parse(j.Text)))
+                                    {
+                                        categoryPath = ItemStringHelper.GetFifthJobName(int.Parse(j.Text), FifthJobSkillToJobID[int.Parse(j.Text)]);
+                                    }
+                                    else
+                                    {
+                                        categoryPath = ItemStringHelper.GetJobName(i) ?? "기타";
+                                    }
+                                    if (!Directory.Exists(Path.Combine(exportedFolder, categoryPath)))
+                                    {
+                                        Directory.CreateDirectory(Path.Combine(exportedFolder, categoryPath));
+                                    }
+                                    string imageName = Path.Combine(exportedFolder, categoryPath, "스킬_" + j.Text + "_" + RemoveInvalidFileNameChars(skillName) + ".png");
+                                    if (File.Exists(imageName)) File.Delete(imageName);
+                                    resultImage.Save(imageName, System.Drawing.Imaging.ImageFormat.Png);
+                                    resultImage.Dispose();
+                                }
+                                if (FifthJobSkillToJobID.Count > 0)
+                                {
+                                    foreach (var kvp in FifthJobSkillToJobID)
+                                    {
+                                        if (kvp.Value.Contains(i))
+                                        {
+                                            var skillNode = PluginManager.FindWz($"Skill\\{kvp.Key / 10000}.img\\skill\\{kvp.Key}", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                            if (skillNode == null)
+                                            {
+                                                continue;
+                                            }
+                                            StringResult sr;
+                                            string skillName;
+                                            if (tooltip.StringLinker == null || !tooltip.StringLinker.StringSkill.TryGetValue(int.Parse(skillNode.Text), out sr))
+                                            {
+                                                sr = new StringResultSkill();
+                                                sr.Name = "알 수없는 스킬";
+                                            }
+                                            skillName = sr.Name;
+                                            labelX2.Text = string.Format("내보내는 중: {0} - {1}", skillNode.Text, skillName);
+                                            Skill skill = Skill.CreateFromNode(skillNode, PluginManager.FindWz, PluginManager.FindWz);
+                                            if (skill != null)
+                                            {
+                                                skill.Level = skill.MaxLevel;
+                                                tooltip.Skill = skill;
+                                            }
+                                            else
+                                            {
+                                                continue;
+                                            }
+                                            Bitmap resultImage = tooltip.Render();
+                                            string categoryPath = ItemStringHelper.GetFifthJobName(kvp.Key, kvp.Value) ?? "기타";
+                                            if (!Directory.Exists(Path.Combine(exportedFolder, categoryPath)))
+                                            {
+                                                Directory.CreateDirectory(Path.Combine(exportedFolder, categoryPath));
+                                            }
+                                            string imageName = Path.Combine(exportedFolder, categoryPath, "스킬_" + skillNode.Text + "_" + RemoveInvalidFileNameChars(skillName) + ".png");
+                                            if (File.Exists(imageName)) File.Delete(imageName);
+                                            resultImage.Save(imageName, System.Drawing.Imaging.ImageFormat.Png);
+                                            resultImage.Dispose();
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBoxEx.Show(ex.ToString(), "오류");
+                    }
+                    finally
+                    {
+                        sw.Stop();
+                        btnSkillTooltipExport.Enabled = true;
+                        labelX2.Text = "내보내기 완료. 시간이 경과했다: " + sw.Elapsed.ToString();
+                    }
+                    labelItemStatus.Text = "내보내기 완료: " + exportedFolder;
+
+                }
+            }
+        }
+
         private void btnExportSkillOption_Click(object sender, EventArgs e)
         {
             FolderBrowserDialog dlg = new FolderBrowserDialog();
@@ -4280,6 +4458,14 @@ namespace WzComparerR2
                 bool isUpdateRequired = await AutomaticCheckUpdate();
                 if (isUpdateRequired) new FrmUpdater().ShowDialog();
             }
+        }
+
+        private static string RemoveInvalidFileNameChars(string fileName)
+        {
+            if (String.IsNullOrEmpty(fileName)) return "Unknown";
+            string invalidChars = new string(System.IO.Path.GetInvalidFileNameChars());
+            string regexPattern = $"[{Regex.Escape(invalidChars)}]";
+            return Regex.Replace(fileName, regexPattern, "_");
         }
     }
 


### PR DESCRIPTION
This feature is ported from JMS fork, and can be accessed from Database tab.
<img width="1183" height="792" alt="image" src="https://github.com/user-attachments/assets/7f5cffb9-806b-4d47-bd66-96b21675ddd0" />
Following jobs are invisible in this list:
- Zen & Jett
- Beast Tamer
- Erel Light
- Iel