### PR TITLE
Add damage skin preview support

### DIFF
--- a/WzComparerR2.Common/CharaSim/DamageSkin.cs
+++ b/WzComparerR2.Common/CharaSim/DamageSkin.cs
@@ -283,6 +283,210 @@ namespace WzComparerR2.CharaSim
                             }
                         }
                         break;
+                    // Legacy below
+                    case "NoRed0":
+                        foreach (Wz_Node digitNode in subNode.Nodes)
+                        {
+                            if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                            {
+                                damageSkin.MiniDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                            }
+                            else if (digitNode.Nodes.Count > 1)
+                            {
+                                foreach (Wz_Node node in digitNode.Nodes)
+                                {
+                                    if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                    {
+                                        damageSkin.MiniDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (digitNode.Text == "numberSpace")
+                            {
+                                damageSkin.MiniDigitSpacing = digitNode.GetValue<int>();
+                            }
+                        }
+                        break;
+                    case "NoRed1":
+                        foreach (Wz_Node digitNode in subNode.Nodes)
+                        {
+                            if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                            {
+                                damageSkin.BigDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                            }
+                            else if (digitNode.Nodes.Count > 1)
+                            {
+                                foreach (Wz_Node node in digitNode.Nodes)
+                                {
+                                    if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                    {
+                                        damageSkin.BigDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (digitNode.Text == "numberSpace")
+                            {
+                                damageSkin.BigDigitSpacing = digitNode.GetValue<int>();
+                            }
+                        }
+                        break;
+                    case "NoCri0":
+                        foreach (Wz_Node digitNode in subNode.Nodes)
+                        {
+                            if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                            {
+                                damageSkin.MiniCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                            }
+                            else if (digitNode.Nodes.Count > 1)
+                            {
+                                foreach (Wz_Node node in digitNode.Nodes)
+                                {
+                                    if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                    {
+                                        damageSkin.MiniCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (digitNode.Text == "numberSpace")
+                            {
+                                damageSkin.MiniCriticalDigitSpacing = digitNode.GetValue<int>();
+                            }
+                        }
+                        break;
+                    case "NoCri1":
+                        foreach (Wz_Node digitNode in subNode.Nodes)
+                        {
+                            if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                            {
+                                damageSkin.BigCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                            }
+                            else if (digitNode.Nodes.Count > 1)
+                            {
+                                foreach (Wz_Node node in digitNode.Nodes)
+                                {
+                                    if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                    {
+                                        damageSkin.BigCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                        break;
+                                    }
+                                }
+                            }
+                            else if (digitNode.Text == "numberSpace")
+                            {
+                                damageSkin.BigCriticalDigitSpacing = digitNode.GetValue<int>();
+                            }
+                        }
+                        break;
+                    case "NoCustom":
+                        foreach (Wz_Node customSubNode in subNode.Nodes)
+                        {
+                            switch (customSubNode.Text)
+                            {
+                                case "NoRed0":
+                                    foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.MiniUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.MiniUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.MiniUnitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoRed1":
+                                    foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.BigUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.BigUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.BigUnitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoCri0":
+                                    foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.MiniCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.MiniCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.MiniCriticalUnitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoCri1":
+                                    foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.BigCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.BigCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.BigCriticalUnitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "customType":
+                                    damageSkin.CustomType = customSubNode.GetValue<string>();
+                                    break;
+                            }
+                        }
+                        break;
                 }
             }
 

--- a/WzComparerR2.Common/CharaSim/DamageSkin.cs
+++ b/WzComparerR2.Common/CharaSim/DamageSkin.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using WzComparerR2.WzLib;
+
+namespace WzComparerR2.CharaSim
+{
+    public class DamageSkin
+    {
+        public DamageSkin()
+        {
+            MiniDigit = new Dictionary<string, BitmapOrigin>();
+            BigDigit = new Dictionary<string, BitmapOrigin>();
+            MiniCriticalDigit = new Dictionary<string, BitmapOrigin>();
+            BigCriticalDigit = new Dictionary<string, BitmapOrigin>();
+            MiniUnit = new Dictionary<string, BitmapOrigin>();
+            BigUnit = new Dictionary<string, BitmapOrigin>();
+            MiniCriticalUnit = new Dictionary<string, BitmapOrigin>();
+            BigCriticalUnit = new Dictionary<string, BitmapOrigin>();
+            EtcBitmap = new Dictionary<string, BitmapOrigin>();
+            MiniDigitSpacing = 0;
+            BigDigitSpacing = 0;
+            MiniCriticalDigitSpacing = 0;
+            BigCriticalDigitSpacing = 0;
+            MiniUnitSpacing = 0;
+            BigUnitSpacing = 0;
+            MiniCriticalUnitSpacing = 0;
+            BigCriticalUnitSpacing = 0;
+        }
+
+        public int DamageSkinID { get; set; }
+        public int ExtractItemID { get; set; }
+        public Dictionary<string, BitmapOrigin> MiniDigit { get; set; }
+        public int MiniDigitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> BigDigit { get; set; }
+        public int BigDigitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> MiniCriticalDigit { get; set; }
+        public int MiniCriticalDigitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> BigCriticalDigit { get; set; }
+        public int BigCriticalDigitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> MiniUnit { get; set; }
+        public int MiniUnitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> BigUnit { get; set; }
+        public int BigUnitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> MiniCriticalUnit { get; set; }
+        public int MiniCriticalUnitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> BigCriticalUnit { get; set; }
+        public int BigCriticalUnitSpacing { get; set; }
+        public Dictionary<string, BitmapOrigin> EtcBitmap { get; set; }
+        public BitmapOrigin Sample { get; set; }
+        public string Desc { get; set; }
+        public string CustomType { get; set; }
+
+        public static DamageSkin CreateFromNode(Wz_Node damageSkinNode, GlobalFindNodeFunction findNode)
+        {
+            if (damageSkinNode == null)
+                return null;
+
+            DamageSkin damageSkin = new DamageSkin();
+
+            damageSkin.DamageSkinID = Convert.ToInt32(damageSkinNode.Text);
+
+            foreach (Wz_Node subNode in damageSkinNode.Nodes)
+            {
+                switch (subNode.Text)
+                {
+                    case "desc":
+                        damageSkin.Desc = subNode.GetValue<string>();
+                        break;
+                    case "extractID":
+                        damageSkin.ExtractItemID = subNode.GetValue<int>();
+                        break;
+                    case "sample":
+                        damageSkin.Sample = BitmapOrigin.CreateFromNode(subNode, findNode);
+                        break;
+                    case "effect":
+                        foreach (Wz_Node effectNode in subNode.Nodes)
+                        {
+                            switch (effectNode.Text)
+                            {
+                                case "NoRed0":
+                                    foreach (Wz_Node digitNode in effectNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.MiniDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.MiniDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.MiniDigitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoRed1":
+                                    foreach (Wz_Node digitNode in effectNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.BigDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.BigDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.BigDigitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoCri0":
+                                    foreach (Wz_Node digitNode in effectNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.MiniCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.MiniCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.MiniCriticalDigitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoCri1":
+                                    foreach (Wz_Node digitNode in effectNode.Nodes)
+                                    {
+                                        if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                        {
+                                            damageSkin.BigCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                        }
+                                        else if (digitNode.Nodes.Count > 1)
+                                        {
+                                            foreach (Wz_Node node in digitNode.Nodes)
+                                            {
+                                                if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                {
+                                                    damageSkin.BigCriticalDigit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        else if (digitNode.Text == "numberSpace")
+                                        {
+                                            damageSkin.BigCriticalDigitSpacing = digitNode.GetValue<int>();
+                                        }
+                                    }
+                                    break;
+                                case "NoCustom":
+                                    foreach (Wz_Node customSubNode in effectNode.Nodes)
+                                    {
+                                        switch (customSubNode.Text)
+                                        {
+                                            case "NoRed0":
+                                                foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                                {
+                                                    if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                                    {
+                                                        damageSkin.MiniUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                                    }
+                                                    else if (digitNode.Nodes.Count > 1)
+                                                    {
+                                                        foreach (Wz_Node node in digitNode.Nodes)
+                                                        {
+                                                            if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                            {
+                                                                damageSkin.MiniUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    else if (digitNode.Text == "numberSpace")
+                                                    {
+                                                        damageSkin.MiniUnitSpacing = digitNode.GetValue<int>();
+                                                    }
+                                                }
+                                                break;
+                                            case "NoRed1":
+                                                foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                                {
+                                                    if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                                    {
+                                                        damageSkin.BigUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                                    }
+                                                    else if (digitNode.Nodes.Count > 1)
+                                                    {
+                                                        foreach (Wz_Node node in digitNode.Nodes)
+                                                        {
+                                                            if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                            {
+                                                                damageSkin.BigUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    else if (digitNode.Text == "numberSpace")
+                                                    {
+                                                        damageSkin.BigUnitSpacing = digitNode.GetValue<int>();
+                                                    }
+                                                }
+                                                break;
+                                            case "NoCri0":
+                                                foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                                {
+                                                    if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                                    {
+                                                        damageSkin.MiniCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                                    }
+                                                    else if (digitNode.Nodes.Count > 1)
+                                                    {
+                                                        foreach (Wz_Node node in digitNode.Nodes)
+                                                        {
+                                                            if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                            {
+                                                                damageSkin.MiniCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    else if (digitNode.Text == "numberSpace")
+                                                    {
+                                                        damageSkin.MiniCriticalUnitSpacing = digitNode.GetValue<int>();
+                                                    }
+                                                }
+                                                break;
+                                            case "NoCri1":
+                                                foreach (Wz_Node digitNode in customSubNode.Nodes)
+                                                {
+                                                    if (digitNode.Value is Wz_Uol || digitNode.Value is Wz_Png)
+                                                    {
+                                                        damageSkin.BigCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(digitNode, findNode));
+                                                    }
+                                                    else if (digitNode.Nodes.Count > 1)
+                                                    {
+                                                        foreach (Wz_Node node in digitNode.Nodes)
+                                                        {
+                                                            if (node.Value is Wz_Uol || node.Value is Wz_Png)
+                                                            {
+                                                                damageSkin.BigCriticalUnit.Add(digitNode.Text, BitmapOrigin.CreateFromNode(node, findNode));
+                                                                break;
+                                                            }
+                                                        }
+                                                    }
+                                                    else if (digitNode.Text == "numberSpace")
+                                                    {
+                                                        damageSkin.BigCriticalUnitSpacing = digitNode.GetValue<int>();
+                                                    }
+                                                }
+                                                break;
+                                            case "customType":
+                                                damageSkin.CustomType = customSubNode.GetValue<string>();
+                                                break;
+                                        }
+                                    }
+                                    break;
+                            }
+                        }
+                        break;
+                }
+            }
+
+            return damageSkin;
+        }
+    }
+}

--- a/WzComparerR2.Common/CharaSim/Familiar.cs
+++ b/WzComparerR2.Common/CharaSim/Familiar.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using WzComparerR2.WzLib;
+
+namespace WzComparerR2.CharaSim
+{
+    public class Familiar
+    {
+        public Familiar()
+        {
+            FamiliarAttribute = "N";
+            FamiliarCategory = 1;
+        }
+
+        public int FamiliarID { get; set; }
+        public int MobID { get; set; }
+        public int MonsterCardID { get; set; }
+        public int FamiliarCategory { get; set; }
+        public int SkillID { get; set; }
+        public int SkillEffectAfter { get; set; }
+        public int Range { get; set; }
+        public string FamiliarAttribute { get; set; }
+        public BitmapOrigin FamiliarCover { get; set; }
+
+        public static Familiar CreateFromNode(Wz_Node node, GlobalFindNodeFunction findNode)
+        {
+            if (node == null)
+                return null;
+            int familiarID;
+            Match m = Regex.Match(node.Text, @"^(\d+)\.img$");
+            if (!(m.Success && Int32.TryParse(m.Result("$1"), out familiarID)))
+            {
+                return null;
+            }
+
+            Familiar familiar = new Familiar();
+
+            familiar.FamiliarID = familiarID;
+
+            Wz_Node standNode = node.FindNodeByPath("stand\\0").ResolveUol();
+            if (standNode != null)
+            {
+                familiar.FamiliarCover = BitmapOrigin.CreateFromNode(standNode, findNode);
+            }
+
+            Wz_Node infoNode = node.FindNodeByPath("info").ResolveUol();
+
+            if (infoNode != null)
+            {
+                foreach (Wz_Node subNode in infoNode.Nodes)
+                {
+                    switch (subNode.Text)
+                    {
+                        case "FAttribute":
+                            familiar.FamiliarAttribute = subNode.GetValue<string>();
+                            break;
+                        case "FCategory":
+                            familiar.FamiliarCategory = subNode.GetValue<int>();
+                            break;
+                        case "MobID":
+                            familiar.MobID = subNode.GetValue<int>();
+                            break;
+                        case "monsterCardID":
+                            familiar.MonsterCardID = subNode.GetValue<int>();
+                            break;
+                        case "range":
+                            familiar.Range = subNode.GetValue<int>();
+                            break;
+                        case "skill":
+                            foreach (Wz_Node skillNode in subNode.Nodes)
+                            {
+                                switch (skillNode.Text)
+                                {
+                                    case "id":
+                                        familiar.SkillID = skillNode.GetValue<int>();
+                                        break;
+                                    case "effectAfter":
+                                        familiar.SkillEffectAfter = skillNode.GetValue<int>();
+                                        break;
+                                }
+                            }
+                            break;
+                        case "portrait":
+                            familiar.FamiliarCover = BitmapOrigin.CreateFromNode(subNode, findNode);
+                            break;
+                    }
+                }
+            }
+
+            return familiar;
+        }
+    }
+}
+

--- a/WzComparerR2.Common/CharaSim/Item.cs
+++ b/WzComparerR2.Common/CharaSim/Item.cs
@@ -26,6 +26,8 @@ namespace WzComparerR2.CharaSim
         public ItemType type { get; set; }
 
         public List<GearLevelInfo> Levels { get; internal set; }
+        public int? FamiliarID { get; set; }
+        public int Grade { get; set; }
 
         public Dictionary<ItemPropType, long> Props { get; private set; }
         public Dictionary<ItemSpecType, long> Specs { get; private set; }
@@ -132,6 +134,14 @@ namespace WzComparerR2.CharaSim
 
                         case "damageSkinID":
                             item.DamageSkinID = Convert.ToInt32(subNode.Value);
+                            break;
+
+                        case "familiarID":
+                            item.FamiliarID = Convert.ToInt32(subNode.Value);
+                            break;
+
+                        case "grade":
+                            item.Grade = Convert.ToInt32(subNode.Value);
                             break;
 
                         case "consumableFrom":

--- a/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
+++ b/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
@@ -103,7 +103,7 @@ namespace WzComparerR2.CharaSim
                 case GearPropType.bdR: return "보스 몬스터 공격 시 데미지 +" + value + "%";
                 case GearPropType.incIMDR:
                 case GearPropType.imdR: return "몬스터 방어율 무시 : +" + value + "%";
-                //case GearPropType.limitBreak:return "伤害上限突破至" + ToChineseNumberExpr(value) + "。";
+                //case GearPropType.limitBreak:return "伤害上限突破至" + ToCJKNumberExpr(value) + "。";
                 case GearPropType.reduceReq: return "착용 레벨 감소 : - " + value;
                 case GearPropType.nbdR: return "일반 몬스터 공격 시 데미지 : +" + value + "%";
 
@@ -1573,34 +1573,196 @@ namespace WzComparerR2.CharaSim
             return jobName;
         }
 
-        public static string ToChineseNumberExpr(long value)
+        public static string ToCJKNumberExpr(long value, bool detailedExpr = false)
         {
-            var sb = new StringBuilder(16);
+            var sb = new StringBuilder(32);
             bool firstPart = true;
             if (value < 0)
             {
                 sb.Append("-");
                 value = -value; // just ignore the exception -2147483648
             }
-            if (value >= 1_0000_0000)
+            if (detailedExpr)
             {
-                long part = value / 1_0000_0000;
-                sb.AppendFormat("{0}억", part);
-                value -= part * 1_0000_0000;
-                firstPart = false;
+                string[] smallUnits = { "", "십", "백", "천" }; // Korean: 십, 백, 천; Chinese+Japanese: 十, 百, 千
+                string[] bigUnits = { "", "만", "억", "조", "경" }; // Korean: 만, 억, 조, 경; TradChinese: 萬, 億, 兆, 京; SimpChinese: 万, 亿, 兆, 京; Japanese: 万, 億, 兆, 京;
+
+                string digits = value.ToString();
+                int len = digits.Length;
+
+                bool blockHasValue = false;
+                int zeroCount = 0;
+
+                for (int i = 0; i < len; i++)
+                {
+                    int posFromRight = len - i - 1;
+                    int smallUnitIndex = posFromRight % 4;
+                    int bigUnitIndex = posFromRight / 4;
+
+                    char d = digits[i];
+
+                    if (d == '0')
+                    {
+                        zeroCount++;
+                    }
+                    else
+                    {
+                        if (zeroCount > 0 && zeroCount <= 3)
+                        {
+                            sb.Append('0');
+                        }
+
+                        zeroCount = 0;
+
+                        sb.Append(d);
+                        if (smallUnitIndex > 0)
+                            sb.Append(smallUnits[smallUnitIndex]);
+
+                        blockHasValue = true;
+                    }
+
+                    if (smallUnitIndex == 0)
+                    {
+                        if (blockHasValue && bigUnitIndex > 0 && bigUnitIndex < bigUnits.Length)
+                            sb.Append(bigUnits[bigUnitIndex]);
+
+                        blockHasValue = false;
+                        zeroCount = 0;
+                    }
+                }
             }
-            if (value >= 1_0000)
+            else
             {
-                long part = value / 1_0000;
-                sb.Append(firstPart ? null : " ");
-                sb.AppendFormat("{0}만", part);
-                value -= part * 1_0000;
-                firstPart = false;
+                if (value >= 1_0000_0000_0000_0000)
+                {
+                    long part = value / 1_0000_0000_0000_0000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}경", part); // Korean: 경, Chinese+Japanese: 京; English: Q
+                    value -= part * 1_0000_0000_0000_0000;
+                    firstPart = false;
+                }
+                if (value >= 1_0000_0000_0000)
+                {
+                    long part = value / 1_0000_0000_0000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}조", part); // Korean: 조, Chinese+Japanese: 兆; English: T
+                    value -= part * 1_0000_0000_0000;
+                    firstPart = false;
+                }
+                if (value >= 1_0000_0000)
+                {
+                    long part = value / 1_0000_0000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}억", part); // Korean: 억, TradChinese+Japanese: 億, SimpChinese: 亿
+                    value -= part * 1_0000_0000;
+                    firstPart = false;
+                }
+                if (value >= 1_0000)
+                {
+                    long part = value / 1_0000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}만", part); // Korean: 만, TradChinese: 萬, SimpChinese+Japanese: 万
+                    value -= part * 1_0000;
+                    firstPart = false;
+                }
+                if (value > 0)
+                {
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}", value);
+                }
             }
-            if (value > 0)
+
+            return sb.Length > 0 ? sb.ToString() : "0";
+        }
+
+        public static string ToThousandsNumberExpr(long value, bool isMsea = false)
+        {
+            var sb = new StringBuilder(32);
+            bool firstPart = true;
+            if (isMsea)
             {
-                sb.Append(firstPart ? null : " ");
-                sb.AppendFormat("{0}", value);
+                if (value < 0)
+                {
+                    sb.Append("-");
+                    value = -value; // just ignore the exception -2147483648
+                }
+                if (value >= 1_0000_0000_0000_0000)
+                {
+                    long part = value / 1_0000_0000_0000_0000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}Q", part);
+                    value -= part * 1_0000_0000_0000_0000;
+                    firstPart = false;
+                }
+                if (value >= 1_000_000_000_000)
+                {
+                    long part = value / 1_000_000_000_000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}T", part);
+                    value -= part * 1_000_000_000_000;
+                    firstPart = false;
+                }
+                if (value >= 1_000_000_000)
+                {
+                    long part = value / 1_000_000_000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}B", part);
+                    value -= part * 1_000_000_000;
+                    firstPart = false;
+                }
+                if (value >= 1_000_000)
+                {
+                    long part = value / 1_000_000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}M", part);
+                    value -= part * 1_000_000;
+                    firstPart = false;
+                }
+                if (value >= 1_000)
+                {
+                    long part = value / 1_000;
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}K", part);
+                    value -= part * 1_000;
+                    firstPart = false;
+                }
+                if (value > 0)
+                {
+                    sb.Append(firstPart ? null : " ");
+                    sb.AppendFormat("{0}", value);
+                }
+            }
+            else
+            {
+                if (value < 0)
+                {
+                    sb.Append("-");
+                    value = -value; // just ignore the exception -2147483648
+                }
+                /* if (value >= 1_000_000_000_000) // For future proofing
+                {
+                    double part = Math.Round((double)value / 1_000_000_000_000, 1);
+                    sb.AppendFormat("{0}T", part);
+                } */
+                if (value >= 1_000_000_000)
+                {
+                    double part = Math.Round((double)value / 1_000_000_000, 1);
+                    sb.AppendFormat("{0}B", part);
+                }
+                else if (value >= 1_000_000)
+                {
+                    double part = Math.Round((double)value / 1_000_000, 1);
+                    sb.AppendFormat("{0}M", part);
+                }
+                else if (value >= 1_000)
+                {
+                    double part = Math.Round((double)value / 1_000, 1);
+                    sb.AppendFormat("{0}K", part);
+                }
+                else if (value > 0)
+                {
+                    sb.AppendFormat("{0}", value);
+                }
             }
 
             return sb.Length > 0 ? sb.ToString() : "0";

--- a/WzComparerR2.Common/StringLinker.cs
+++ b/WzComparerR2.Common/StringLinker.cs
@@ -11,6 +11,7 @@ namespace WzComparerR2.Common
         public StringLinker()
         {
             stringEqp = new Dictionary<int, StringResult>();
+            stringFamiliarSkill = new Dictionary<int, StringResult>();
             stringItem = new Dictionary<int, StringResult>();
             stringMap = new Dictionary<int, StringResult>();
             stringMob = new Dictionary<int, StringResult>();
@@ -105,6 +106,31 @@ namespace WzComparerR2.Common
 
                                     AddAllValue(strResult, linkNode);
                                     stringItem[id] = strResult;
+                                }
+                            }
+                        }
+                        break;
+                    case "Familiar.img":
+                    case "FamiliarSkill.img":
+                        if (!image.TryExtract()) break;
+                        foreach (Wz_Node tree0 in image.Node.Nodes)
+                        {
+                            if (tree0.Text == "skill")
+                            {
+                                foreach (Wz_Node tree1 in tree0.Nodes)
+                                {
+                                    if (Int32.TryParse(tree1.Text, out id) && tree1.ResolveUol() is Wz_Node linkNode)
+                                    {
+                                        StringResult strResult = null;
+                                        if (strResult == null) strResult = new StringResult();
+
+                                        strResult.Name = GetDefaultString(linkNode, "name") ?? strResult.Name ?? string.Empty;
+                                        strResult.Desc = GetDefaultString(linkNode, "desc") ?? strResult.Desc;
+                                        strResult.FullPath = tree1.FullPath;
+
+                                        AddAllValue(strResult, linkNode);
+                                        stringFamiliarSkill[id] = strResult;
+                                    }
                                 }
                             }
                         }
@@ -443,6 +469,7 @@ namespace WzComparerR2.Common
         public void Clear()
         {
             stringEqp.Clear();
+            stringFamiliarSkill.Clear();
             stringItem.Clear();
             stringMob.Clear();
             stringMap.Clear();
@@ -464,6 +491,7 @@ namespace WzComparerR2.Common
         }
 
         private Dictionary<int, StringResult> stringEqp;
+        private Dictionary<int, StringResult> stringFamiliarSkill;
         private Dictionary<int, StringResult> stringItem;
         private Dictionary<int, StringResult> stringMap;
         private Dictionary<int, StringResult> stringMob;
@@ -494,6 +522,11 @@ namespace WzComparerR2.Common
         public Dictionary<int, StringResult> StringEqp
         {
             get { return stringEqp; }
+        }
+
+        public Dictionary<int, StringResult> StringFamiliarSkill
+        {
+            get { return stringFamiliarSkill; }
         }
 
         public Dictionary<int, StringResult> StringItem

--- a/WzComparerR2/CharaSimControl/AfrmTooltip.cs
+++ b/WzComparerR2/CharaSimControl/AfrmTooltip.cs
@@ -21,6 +21,7 @@ namespace WzComparerR2.CharaSimControl
 
             this.Size = new Size(1, 1);
             this.HideOnHover = true;
+            this.FamiliarRender = new FamiliarTooltipRender();
             this.GearRender = new GearTooltipRender2();
             this.GearRender22 = new GearTooltipRender22();
             this.ItemRender = new ItemTooltipRender2();
@@ -56,6 +57,8 @@ namespace WzComparerR2.CharaSimControl
         public StringLinker StringLinker { get; set; }
         public Character Character { get; set; }
 
+        
+        public FamiliarTooltipRender FamiliarRender { get; private set; }
         public GearTooltipRender2 GearRender { get; private set; }
         public GearTooltipRender22 GearRender22 { get; private set; }
         public ItemTooltipRender2 ItemRender { get; private set; }
@@ -84,6 +87,7 @@ namespace WzComparerR2.CharaSimControl
             set
             {
                 this.showID = value;
+                this.FamiliarRender.ShowObjectID = value;
                 this.GearRender.ShowObjectID = value;
                 this.GearRender22.ShowObjectID = value;
                 this.ItemRender.ShowObjectID = value;
@@ -195,6 +199,12 @@ namespace WzComparerR2.CharaSimControl
                     renderer = ItemRender;
                     ItemRender.Item = this.item as Item;
                 }
+            }
+            else if (item is Familiar)
+            {
+                renderer = FamiliarRender;
+                FamiliarRender.Familiar = this.item as Familiar;
+                // FamiliarRender.UseAssembleUI = EnableAssembleTooltip;
             }
             else if (item is Gear)
             {

--- a/WzComparerR2/CharaSimControl/DamageSkinTooltipRenderer.cs
+++ b/WzComparerR2/CharaSimControl/DamageSkinTooltipRenderer.cs
@@ -1,0 +1,645 @@
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using WzComparerR2.CharaSim;
+using Resource = CharaSimResource.Resource;
+
+namespace WzComparerR2.CharaSimControl
+{
+    public class DamageSkinTooltipRenderer : TooltipRender
+    {
+        public DamageSkinTooltipRenderer()
+        {
+        }
+
+        private DamageSkin damageSkin;
+
+        public DamageSkin DamageSkin
+        {
+            get { return damageSkin; }
+            set { damageSkin = value; }
+        }
+
+
+        public override object TargetItem
+        {
+            get { return this.damageSkin; }
+            set { this.damageSkin = value as DamageSkin; }
+        }
+
+        public bool UseMiniSize { get; set; }
+        public bool AlwaysUseMseaFormat { get; set; }
+        public bool DisplayUnitOnSingleLine { get; set; }
+        public long DamageSkinNumber { get; set; }
+
+        public override Bitmap Render()
+        {
+            if (this.damageSkin == null)
+            {
+                return null;
+            }
+
+            Bitmap customSampleNonCritical = GetCustomSample(DamageSkinNumber, UseMiniSize, false);
+            Bitmap customSampleCritical = GetCustomSample(DamageSkinNumber, UseMiniSize, true);
+            Bitmap extraBitmap = GetExtraEffect();
+            Bitmap unitBitmap = null;
+
+            int previewWidth = Math.Max(customSampleNonCritical.Width, customSampleCritical.Width);
+            int previewHeight = customSampleNonCritical.Height + customSampleCritical.Height;
+
+            if (extraBitmap != null)
+            {
+                previewWidth = Math.Max(previewWidth, extraBitmap.Width);
+                previewHeight += extraBitmap.Height;
+                if (DisplayUnitOnSingleLine)
+                {
+                    unitBitmap = GetUnit();
+                    if (unitBitmap != null)
+                    {
+                        previewWidth = Math.Max(previewWidth, unitBitmap.Width);
+                        previewHeight += unitBitmap.Height;
+                    }
+                }
+            }
+
+            int picH = 10;
+
+            Bitmap tooltip = new Bitmap(previewWidth + 30, previewHeight + 30);
+            Graphics g = Graphics.FromImage(tooltip);
+
+            GearGraphics.DrawNewTooltipBack(g, 0, 0, tooltip.Width, tooltip.Height);
+
+            if (this.ShowObjectID)
+            {
+                GearGraphics.DrawGearDetailNumber(g, 3, 3, $"{this.damageSkin.DamageSkinID.ToString()}", true);
+            }
+
+            g.DrawImage(customSampleNonCritical, 10, picH, new Rectangle(0, 0, customSampleNonCritical.Width, customSampleNonCritical.Height), GraphicsUnit.Pixel);
+
+            picH += customSampleNonCritical.Height + 5;
+
+            g.DrawImage(customSampleCritical, 10, picH, new Rectangle(0, 0, customSampleCritical.Width, customSampleCritical.Height), GraphicsUnit.Pixel);
+
+            picH += customSampleCritical.Height + 5;
+
+            if (unitBitmap != null)
+            {
+                g.DrawImage(unitBitmap, 10, picH, new Rectangle(0, 0, unitBitmap.Width, unitBitmap.Height), GraphicsUnit.Pixel);
+                picH += unitBitmap.Height + 5;
+            }
+
+            if (extraBitmap != null)
+            {
+                g.DrawImage(extraBitmap, 10, picH, new Rectangle(0, 0, extraBitmap.Width, extraBitmap.Height), GraphicsUnit.Pixel);
+            }
+
+            customSampleNonCritical.Dispose();
+            customSampleCritical.Dispose();
+            g.Dispose();
+            return tooltip;
+        }
+
+        public Bitmap GetCustomSample(long inputNumber, bool useMiniSize, bool isCritical)
+        {
+            string numberStr = "";
+            if (DisplayUnitOnSingleLine)
+            {
+                numberStr = inputNumber.ToString();
+            }
+            else
+            {
+                switch (damageSkin.CustomType)
+                {
+                    case "hangul": // CJK Detailed
+                        numberStr = ItemStringHelper.ToCJKNumberExpr(inputNumber, true);
+                        break;
+                    case "hangulUnit": // CJK
+                        numberStr = ItemStringHelper.ToCJKNumberExpr(inputNumber);
+                        break;
+                    case "glUnit": // GMS
+                        numberStr = ItemStringHelper.ToThousandsNumberExpr(inputNumber, this.AlwaysUseMseaFormat);
+                        break;
+                    case "glUnit2": // MSEA
+                        numberStr = ItemStringHelper.ToThousandsNumberExpr(inputNumber, true);
+                        break;
+                    default:
+                        if (this.DamageSkin.MiniUnit.Count > 0) // Default to CJK format when units are available
+                        {
+                            numberStr = ItemStringHelper.ToCJKNumberExpr(inputNumber);
+                        }
+                        else
+                        {
+                            numberStr = inputNumber.ToString();
+                        }
+                        break;
+                }
+            }
+
+
+            Bitmap criticalSign = null;
+            if (this.damageSkin.BigCriticalDigit.ContainsKey("effect3"))
+            {
+                criticalSign = this.damageSkin.BigCriticalDigit["effect3"].Bitmap;
+            }
+
+            int totalWidth = 0;
+            int maxHeight = 0;
+            int digitSpacing = isCritical ?
+                            (useMiniSize ? this.damageSkin.MiniCriticalDigitSpacing :
+                            this.damageSkin.BigCriticalDigitSpacing) :
+                            (useMiniSize ? this.damageSkin.MiniDigitSpacing :
+                            this.damageSkin.BigDigitSpacing);
+            int unitSpacing = isCritical ?
+                            (useMiniSize ? this.damageSkin.MiniCriticalUnitSpacing :
+                            this.damageSkin.BigCriticalUnitSpacing) :
+                            (useMiniSize ? this.damageSkin.MiniUnitSpacing :
+                            this.damageSkin.BigUnitSpacing);
+
+            if (isCritical && criticalSign != null)
+            {
+                totalWidth += criticalSign.Width + unitSpacing;
+                maxHeight = Math.Max(maxHeight, criticalSign.Height);
+            }
+
+            // Calculate total width and max height
+            foreach (char c in numberStr)
+            {
+                string character = c.ToString();
+                switch (character)
+                {
+                    case "0":
+                    case "1":
+                    case "2":
+                    case "3":
+                    case "4":
+                    case "5":
+                    case "6":
+                    case "7":
+                    case "8":
+                    case "9":
+                        totalWidth += isCritical ?
+                            (useMiniSize ? this.damageSkin.MiniCriticalDigit[character].Bitmap.Width :
+                            this.damageSkin.BigCriticalDigit[character].Bitmap.Width) :
+                            (useMiniSize ? this.damageSkin.MiniDigit[character].Bitmap.Width :
+                            this.damageSkin.BigDigit[character].Bitmap.Width);
+                        totalWidth += digitSpacing;
+                        maxHeight = Math.Max(maxHeight, isCritical ?
+                            (useMiniSize ? this.damageSkin.MiniCriticalDigit[character].Bitmap.Height :
+                            this.damageSkin.BigCriticalDigit[character].Bitmap.Height) :
+                            (useMiniSize ? this.damageSkin.MiniDigit[character].Bitmap.Height :
+                            this.damageSkin.BigDigit[character].Bitmap.Height));
+                        break;
+
+                    case "十":
+                    case "십":
+                    case ".":
+                        if (this.damageSkin.BigUnit.ContainsKey("0"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["0"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["0"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["0"].Bitmap.Width :
+                                this.damageSkin.BigUnit["0"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["0"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["0"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["0"].Bitmap.Height :
+                                this.damageSkin.BigUnit["0"].Bitmap.Height));
+                        }
+                        break;
+
+                    case "百":
+                    case "백":
+                    case "K":
+                        if (this.damageSkin.BigUnit.ContainsKey("1"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["1"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["1"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["1"].Bitmap.Width :
+                                this.damageSkin.BigUnit["1"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["1"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["1"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["1"].Bitmap.Height :
+                                this.damageSkin.BigUnit["1"].Bitmap.Height));
+                        }
+                        break;
+
+                    case "千":
+                    case "천":
+                    case "M":
+                        if (this.damageSkin.BigUnit.ContainsKey("2"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["2"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["2"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["2"].Bitmap.Width :
+                                this.damageSkin.BigUnit["2"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["2"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["2"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["2"].Bitmap.Height :
+                                this.damageSkin.BigUnit["2"].Bitmap.Height));
+                        }
+                        break;
+
+                    case "万":
+                    case "萬":
+                    case "만":
+                    case "B":
+                        if (this.damageSkin.BigUnit.ContainsKey("3"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["3"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["3"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["3"].Bitmap.Width :
+                                this.damageSkin.BigUnit["3"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["3"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["3"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["3"].Bitmap.Height :
+                                this.damageSkin.BigUnit["3"].Bitmap.Height));
+                        }
+                        break;
+
+                    case "億":
+                    case "亿":
+                    case "억":
+                    case "T":
+                        if (this.damageSkin.BigUnit.ContainsKey("4"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["4"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["4"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["4"].Bitmap.Width :
+                                this.damageSkin.BigUnit["4"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["4"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["4"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["4"].Bitmap.Height :
+                                this.damageSkin.BigUnit["4"].Bitmap.Height));
+                        }
+                        else if (character == "T")
+                        {
+                            totalWidth += Resource.Unit_T.Width;
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, Resource.Unit_T.Height);
+                        }
+                        break;
+
+
+                    case "兆":
+                    case "조":
+                    case "Q":
+                        if (this.damageSkin.BigUnit.ContainsKey("5"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["5"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["5"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["5"].Bitmap.Width :
+                                this.damageSkin.BigUnit["5"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["5"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["5"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["5"].Bitmap.Height :
+                                this.damageSkin.BigUnit["5"].Bitmap.Height));
+                        }
+                        else if (character == "兆" || character == "조")
+                        {
+                            totalWidth += Resource.Unit_E12.Width;
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, Resource.Unit_E12.Height);
+                        }
+                        else if (character == "Q")
+                        {
+                            totalWidth += Resource.Unit_Q.Width;
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, Resource.Unit_Q.Height);
+                        }
+                        break;
+
+                    case "京":
+                    case "경":
+                        if (this.damageSkin.BigUnit.ContainsKey("6"))
+                        {
+                            totalWidth += isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["6"].Bitmap.Width :
+                                this.damageSkin.BigCriticalUnit["6"].Bitmap.Width) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["6"].Bitmap.Width :
+                                this.damageSkin.BigUnit["6"].Bitmap.Width);
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalUnit["6"].Bitmap.Height :
+                                this.damageSkin.BigCriticalUnit["6"].Bitmap.Height) :
+                                (useMiniSize ? this.damageSkin.MiniUnit["6"].Bitmap.Height :
+                                this.damageSkin.BigUnit["6"].Bitmap.Height));
+                        }
+                        else if (character == "京" || character == "경")
+                        {
+                            totalWidth += Resource.Unit_E16.Width;
+                            totalWidth += unitSpacing;
+                            maxHeight = Math.Max(maxHeight, Resource.Unit_E12.Height);
+                        }
+                        break;
+                }
+            }
+
+            Bitmap finalBitmap = new Bitmap(totalWidth, maxHeight);
+
+            using (Graphics g = Graphics.FromImage(finalBitmap))
+            {
+                g.Clear(Color.Transparent);
+                int offsetX = 0;
+                if (isCritical && criticalSign != null)
+                {
+                    g.DrawImage(criticalSign, offsetX, 0);
+                    offsetX += criticalSign.Width;
+                }
+                foreach (char c in numberStr)
+                {
+                    string character = c.ToString();
+                    Bitmap charBitmap = null;
+                    switch (character)
+                    {
+                        case "0":
+                        case "1":
+                        case "2":
+                        case "3":
+                        case "4":
+                        case "5":
+                        case "6":
+                        case "7":
+                        case "8":
+                        case "9":
+                            charBitmap = isCritical ?
+                                (useMiniSize ? this.damageSkin.MiniCriticalDigit[character].Bitmap :
+                                this.damageSkin.BigCriticalDigit[character].Bitmap) :
+                                (useMiniSize ? this.damageSkin.MiniDigit[character].Bitmap :
+                                this.damageSkin.BigDigit[character].Bitmap);
+                            g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                            offsetX += charBitmap.Width + digitSpacing;
+                            break;
+
+                        case "十":
+                        case "십":
+                        case ".":
+                            if (this.damageSkin.BigUnit.ContainsKey("0"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["0"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["0"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["0"].Bitmap :
+                                    this.damageSkin.BigUnit["0"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+                        case "百":
+                        case "백":
+                        case "K":
+                            if (this.damageSkin.BigUnit.ContainsKey("1"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["1"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["1"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["1"].Bitmap :
+                                    this.damageSkin.BigUnit["1"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+                        case "千":
+                        case "천":
+                        case "M":
+                            if (this.damageSkin.BigUnit.ContainsKey("2"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["2"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["2"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["2"].Bitmap :
+                                    this.damageSkin.BigUnit["2"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+                        case "万":
+                        case "萬":
+                        case "만":
+                        case "B":
+                            if (this.damageSkin.BigUnit.ContainsKey("3"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["3"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["3"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["3"].Bitmap :
+                                    this.damageSkin.BigUnit["3"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+                        case "億":
+                        case "亿":
+                        case "억":
+                        case "T":
+                            if (this.damageSkin.BigUnit.ContainsKey("4"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["4"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["4"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["4"].Bitmap :
+                                    this.damageSkin.BigUnit["4"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            else if (character == "T")
+                            {
+                                charBitmap = Resource.Unit_T;
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+
+                        case "兆":
+                        case "조":
+                        case "Q":
+                            if (this.damageSkin.BigUnit.ContainsKey("5"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["5"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["5"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["5"].Bitmap :
+                                    this.damageSkin.BigUnit["5"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            else if (character == "兆" || character == "조")
+                            {
+                                charBitmap = Resource.Unit_E12;
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            else if (character == "Q")
+                            {
+                                charBitmap = Resource.Unit_Q;
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+
+                        case "京":
+                        case "경":
+                            if (this.damageSkin.BigUnit.ContainsKey("6"))
+                            {
+                                charBitmap = isCritical ?
+                                    (useMiniSize ? this.damageSkin.MiniCriticalUnit["6"].Bitmap :
+                                    this.damageSkin.BigCriticalUnit["6"].Bitmap) :
+                                    (useMiniSize ? this.damageSkin.MiniUnit["6"].Bitmap :
+                                    this.damageSkin.BigUnit["6"].Bitmap);
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            else if (character == "京" || character == "경")
+                            {
+                                charBitmap = Resource.Unit_E16;
+                                g.DrawImage(charBitmap, offsetX, maxHeight - charBitmap.Height);
+                                offsetX += charBitmap.Width + unitSpacing;
+                            }
+                            break;
+                    }
+                }
+            }
+            return finalBitmap;
+        }
+
+        public Bitmap GetUnit()
+        {
+            Bitmap unitBitmap = null;
+
+            int width = 0;
+            int height = 0;
+
+            if (damageSkin.BigUnit.Count > 0)
+            {
+                if (UseMiniSize)
+                {
+                    foreach (var unit in damageSkin.MiniUnit.Values)
+                    {
+                        width += unit.Bitmap.Width;
+                        height = Math.Max(height, unit.Bitmap.Height);
+                        width += this.damageSkin.MiniUnitSpacing;
+                    }
+                    foreach (var unit in damageSkin.MiniCriticalUnit.Values)
+                    {
+                        width += unit.Bitmap.Width;
+                        height = Math.Max(height, unit.Bitmap.Height);
+                        width += this.damageSkin.MiniCriticalUnitSpacing;
+                    }
+                    unitBitmap = new Bitmap(width, height);
+                    using (Graphics g = Graphics.FromImage(unitBitmap))
+                    {
+                        g.Clear(Color.Transparent);
+                        int offsetX = 0;
+                        foreach (var unit in damageSkin.MiniUnit.Values)
+                        {
+                            g.DrawImage(unit.Bitmap, offsetX, height - unit.Bitmap.Height);
+                            offsetX += unit.Bitmap.Width;
+                            offsetX += this.damageSkin.MiniUnitSpacing;
+                        }
+                        foreach (var unit in damageSkin.MiniCriticalUnit.Values)
+                        {
+                            g.DrawImage(unit.Bitmap, offsetX, height - unit.Bitmap.Height);
+                            offsetX += unit.Bitmap.Width;
+                            offsetX += this.damageSkin.MiniCriticalUnitSpacing;
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var unit in damageSkin.BigUnit.Values)
+                    {
+                        width += unit.Bitmap.Width;
+                        height = Math.Max(height, unit.Bitmap.Height);
+                        width += this.damageSkin.BigUnitSpacing;
+                    }
+                    foreach (var unit in damageSkin.BigCriticalUnit.Values)
+                    {
+                        width += unit.Bitmap.Width;
+                        height = Math.Max(height, unit.Bitmap.Height);
+                        width += this.damageSkin.BigCriticalUnitSpacing;
+                    }
+                    unitBitmap = new Bitmap(width, height);
+                    using (Graphics g = Graphics.FromImage(unitBitmap))
+                    {
+                        g.Clear(Color.Transparent);
+                        int offsetX = 0;
+                        foreach (var unit in damageSkin.BigUnit.Values)
+                        {
+                            g.DrawImage(unit.Bitmap, offsetX, height - unit.Bitmap.Height);
+                            offsetX += unit.Bitmap.Width;
+                            offsetX += this.damageSkin.BigUnitSpacing;
+                        }
+                        foreach (var unit in damageSkin.BigCriticalUnit.Values)
+                        {
+                            g.DrawImage(unit.Bitmap, offsetX, height - unit.Bitmap.Height);
+                            offsetX += unit.Bitmap.Width;
+                            offsetX += this.damageSkin.BigCriticalUnitSpacing;
+                        }
+                    }
+                }
+            }
+            return unitBitmap;
+        }
+
+        public Bitmap GetExtraEffect()
+        {
+
+            Bitmap[] originalBitmaps = new Bitmap[5]
+            {
+                this.damageSkin.MiniDigit.ContainsKey("Miss") ? this.damageSkin.MiniDigit?["Miss"].Bitmap : null,
+                this.damageSkin.MiniDigit.ContainsKey("guard") ? this.damageSkin.MiniDigit?["guard"].Bitmap : null,
+                this.damageSkin.MiniDigit.ContainsKey("resist") ? this.damageSkin.MiniDigit?["resist"].Bitmap : null,
+                this.damageSkin.MiniDigit.ContainsKey("shot") ? this.damageSkin.MiniDigit?["shot"].Bitmap : null,
+                this.damageSkin.MiniDigit.ContainsKey("counter") ? this.damageSkin.MiniDigit?["counter"].Bitmap : null
+            };
+
+
+            int width = 0;
+            int height = 0;
+
+            foreach (var bo in originalBitmaps)
+            {
+                if (bo == null) continue;
+                width += bo.Width;
+                height = Math.Max(height, bo.Height);
+            }
+
+            Bitmap bitmap = new Bitmap(width, height);
+
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.Clear(Color.Transparent);
+                int offsetX = 0;
+                for (int j = 0; j < originalBitmaps.Count(); j++)
+                {
+                    if (originalBitmaps[j] == null) continue;
+                    g.DrawImage(originalBitmaps[j], offsetX, height - originalBitmaps[j].Height);
+                    offsetX += originalBitmaps[j].Width;
+                }
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/WzComparerR2/CharaSimControl/FamiliarTooltipRender.cs
+++ b/WzComparerR2/CharaSimControl/FamiliarTooltipRender.cs
@@ -1,0 +1,268 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using WzComparerR2.CharaSim;
+using WzComparerR2.Common;
+using WzComparerR2.PluginBase;
+using static WzComparerR2.CharaSimControl.RenderHelper;
+using Resource = CharaSimResource.Resource;
+
+namespace WzComparerR2.CharaSimControl
+{
+    public class FamiliarTooltipRender : TooltipRender
+    {
+        public FamiliarTooltipRender()
+        {
+        }
+
+        private Familiar familiar;
+
+        public Familiar Familiar
+        {
+            get { return familiar; }
+            set { familiar = value; }
+        }
+
+        public override object TargetItem
+        {
+            get { return this.familiar; }
+            set { this.familiar = value as Familiar; }
+        }
+
+        public int? ItemID { get; set; }
+        public int FamiliarTier { get; set; }
+        public bool AllowOutOfBounds { get; set; }
+        public bool UseAssembleUI { get; set; }
+
+        public override Bitmap Render()
+        {
+            if (this.familiar == null)
+            {
+                return null;
+            }
+            return UseAssembleUI ? GeneratePostAssembleFamiliarCard() : GeneratePreAssembleFamiliarCard();
+        }
+
+        private Bitmap GeneratePreAssembleFamiliarCard()
+        {
+            Bitmap baseTooltip = Resource.UIFamiliar_img_familiarCard_backgrnd;
+
+            // Get Mob image and name
+            Mob mob = Mob.CreateFromNode(PluginManager.FindWz($@"Mob\{familiar.MobID.ToString().PadLeft(7, '0')}.img", this.SourceWzFile), PluginManager.FindWz, PluginManager.FindWz);
+            Point alignOrigin = new Point(161, 200);
+            Point mobOrigin = new Point(0, 0);
+            int mobXoffset = 0;
+            int mobYoffset = 0;
+            int tDelta = 0;
+            int bDelta = 0;
+            int lDelta = 0;
+            int rDelta = 0;
+            if (familiar.FamiliarCover.Bitmap != null)
+            {
+                mobOrigin = familiar.FamiliarCover.Origin;
+            }
+            else
+            {
+                mobOrigin = mob.Default.Origin;
+            }
+            Bitmap mobImg = Crop(familiar.FamiliarCover.Bitmap ?? mob.Default.Bitmap, alignOrigin, mobOrigin, out mobXoffset, out mobYoffset, out tDelta, out bDelta, out lDelta, out rDelta);
+
+            Bitmap tooltip = new Bitmap(baseTooltip.Width + lDelta + rDelta, baseTooltip.Height + tDelta + bDelta);
+
+            using (Graphics g = Graphics.FromImage(tooltip))
+            {
+                g.Clear(Color.Transparent);
+                g.DrawImage(baseTooltip, lDelta, tDelta, new Rectangle(0, 0, baseTooltip.Width, baseTooltip.Height), GraphicsUnit.Pixel);
+
+                // Draw Familiar Card basic background
+                g.DrawImage(Resource.UIFamiliar_img_familiarCard_base, 45 + lDelta, 37 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_familiarCard_base.Width, Resource.UIFamiliar_img_familiarCard_base.Height), GraphicsUnit.Pixel);
+                g.DrawImage(Resource.UIFamiliar_img_familiarCard_name, 31 + lDelta, 222 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_familiarCard_name.Width, Resource.UIFamiliar_img_familiarCard_name.Height), GraphicsUnit.Pixel);
+
+                g.DrawImage(mobImg, mobXoffset + lDelta, mobYoffset + tDelta, new Rectangle(0, 0, mobImg.Width, mobImg.Height), GraphicsUnit.Pixel);
+
+                if (this.FamiliarTier == 4)
+                {
+                    // draw Legendary bezel
+                    g.DrawImage(Resource.UIFamiliar_img_familiarCard_legendary, 35 + lDelta, 24 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_familiarCard_legendary.Width, Resource.UIFamiliar_img_familiarCard_legendary.Height), GraphicsUnit.Pixel);
+                }
+
+                g.DrawImage(Resource.UIFamiliar_img_jewel_backgrnd, 25 + lDelta, 21 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_backgrnd.Width, Resource.UIFamiliar_img_jewel_backgrnd.Height), GraphicsUnit.Pixel);
+
+                switch (this.FamiliarTier)
+                {
+                    default:
+                    case 0:
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_normal_5, 30 + lDelta, 27 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_normal_5.Width, Resource.UIFamiliar_img_jewel_normal_5.Height), GraphicsUnit.Pixel);
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_normal_0, 38 + lDelta, 25 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_normal_0.Width, Resource.UIFamiliar_img_jewel_normal_0.Height), GraphicsUnit.Pixel);
+                        break;
+                    case 1:
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_rare_5, 30 + lDelta, 27 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_rare_5.Width, Resource.UIFamiliar_img_jewel_rare_5.Height), GraphicsUnit.Pixel);
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_rare_0, 38 + lDelta, 25 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_rare_0.Width, Resource.UIFamiliar_img_jewel_rare_0.Height), GraphicsUnit.Pixel);
+                        break;
+                    case 2:
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_epic_5, 30 + lDelta, 27 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_epic_5.Width, Resource.UIFamiliar_img_jewel_epic_5.Height), GraphicsUnit.Pixel);
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_epic_0, 38 + lDelta, 25 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_epic_0.Width, Resource.UIFamiliar_img_jewel_epic_0.Height), GraphicsUnit.Pixel);
+                        break;
+                    case 3:
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_unique_5, 30 + lDelta, 27 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_unique_5.Width, Resource.UIFamiliar_img_jewel_unique_5.Height), GraphicsUnit.Pixel);
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_unique_0, 38 + lDelta, 25 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_unique_0.Width, Resource.UIFamiliar_img_jewel_unique_0.Height), GraphicsUnit.Pixel);
+                        break;
+                    case 4:
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_legendary_5, 30 + lDelta, 27 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_legendary_5.Width, Resource.UIFamiliar_img_jewel_legendary_5.Height), GraphicsUnit.Pixel);
+                        g.DrawImage(Resource.UIFamiliar_img_jewel_legendary_0, 38 + lDelta, 25 + tDelta, new Rectangle(0, 0, Resource.UIFamiliar_img_jewel_legendary_0.Width, Resource.UIFamiliar_img_jewel_legendary_0.Height), GraphicsUnit.Pixel);
+                        break;
+                }
+
+                // Pre-Drawing
+                List<TextBlock> titleBlocks = new List<TextBlock>();
+                string mobName = GetMobName(mob.ID);
+                var block = PrepareText(g, mobName ?? "(null)", GearGraphics.EpicGearDetailFont, Brushes.White, 0, 0);
+                titleBlocks.Add(block);
+
+                Rectangle titleRect = Measure(titleBlocks);
+
+                int titleXoffset = Resource.UIFamiliar_img_familiarCard_name.Width >= Resource.UIFamiliar_img_familiarCard_name.Width ? (Resource.UIFamiliar_img_familiarCard_name.Width - titleRect.Width) / 2 : 0;
+                int titleYoffset = (Resource.UIFamiliar_img_familiarCard_name.Height - titleRect.Height) / 2;
+
+                foreach (var item in titleBlocks)
+                {
+                    DrawText(g, item, new Point(31 + lDelta + titleXoffset, 222 + tDelta + titleYoffset));
+                }
+
+                // Draw Skill
+                string skillName = GetFamiliarSkillName(this.familiar.SkillID);
+                if (!string.IsNullOrEmpty(skillName))
+                {
+                    List<TextBlock> skillBlocks = new List<TextBlock>();
+                    block = PrepareText(g, skillName, GearGraphics.EpicGearDetailFont, Brushes.White, 0, 0);
+                    skillBlocks.Add(block);
+
+                    Rectangle skillRect = Measure(skillBlocks);
+
+                    int skillXoffset = Resource.UIFamiliar_img_familiarCard_name.Width >= Resource.UIFamiliar_img_familiarCard_name.Width ? (Resource.UIFamiliar_img_familiarCard_name.Width - skillRect.Width) / 2 : 0;
+                    int skillYoffset = Resource.UIFamiliar_img_familiarCard_name.Height + 1;
+
+                    foreach (var item in skillBlocks)
+                    {
+                        DrawText(g, item, new Point(31 + lDelta + skillXoffset, 222 + tDelta + skillYoffset));
+                    }
+
+                }
+
+
+                // Layout
+                if (this.ShowObjectID)
+                {
+                    GearGraphics.DrawGearDetailNumber(g, 24 + lDelta, 24 + tDelta, this.ItemID != null ? $"{((int)this.ItemID).ToString("d8")}" : $"{this.familiar.FamiliarID.ToString()}", true);
+                }
+            }
+            return tooltip;
+        }
+
+        private Bitmap GeneratePostAssembleFamiliarCard()
+        {
+            // To be implemented
+            return GeneratePreAssembleFamiliarCard();
+        }
+
+        private string GetMobName(int mobID)
+        {
+            StringResult sr;
+            if (this.StringLinker == null || !this.StringLinker.StringMob.TryGetValue(mobID, out sr))
+            {
+                return null;
+            }
+            else
+            {
+                return sr.Name;
+            }
+        }
+
+        private string GetFamiliarSkillName(int skillID)
+        {
+            StringResult sr;
+            if (this.StringLinker == null || !this.StringLinker.StringFamiliarSkill.TryGetValue(skillID, out sr))
+            {
+                return null;
+            }
+            else
+            {
+                return sr.Name;
+            }
+        }
+
+        private Bitmap Crop(Bitmap sourceBmp, Point alignOrigin, Point mobOrigin, out int xOffset, out int yOffset, out int tDelta, out int bDelta, out int lDelta, out int rDelta)
+        {
+            tDelta = 0;
+            bDelta = 0;
+            lDelta = 0;
+            rDelta = 0;
+            xOffset = 0;
+            yOffset = 0;
+
+            if (sourceBmp == null)
+            {
+                return null;
+            }
+
+            xOffset = alignOrigin.X - mobOrigin.X;
+            yOffset = alignOrigin.Y - mobOrigin.Y;
+
+            if (this.AllowOutOfBounds)
+            {
+                lDelta = mobOrigin.X > alignOrigin.X ? mobOrigin.X - alignOrigin.X : 0;
+                rDelta = sourceBmp.Width - mobOrigin.X > 154 ? sourceBmp.Width - mobOrigin.X - 154 : 0;
+                tDelta = mobOrigin.Y > alignOrigin.Y ? mobOrigin.Y - alignOrigin.Y : 0;
+                bDelta = sourceBmp.Height - mobOrigin.Y > 228 ? sourceBmp.Height - mobOrigin.Y - 228 : 0;
+                return sourceBmp;
+            }
+
+            int rectangXoffset = 0;
+            int rectangYoffset = 0;
+            int rectangWidth = 0;
+            int rectangHeight = 0;
+
+            if (mobOrigin.X > 108) // Define Left Border
+            {
+                rectangXoffset = mobOrigin.X - 108;
+                rectangWidth += 108;
+            }
+            else
+            {
+                rectangWidth += mobOrigin.X;
+            }
+
+            if (sourceBmp.Width - mobOrigin.X > 104) // Define Right Border
+            {
+                rectangWidth += 104;
+            }
+            else
+            {
+                rectangWidth += sourceBmp.Width - mobOrigin.X;
+            }
+
+            if (mobOrigin.Y > 154) // Define Top Border
+            {
+                rectangYoffset = mobOrigin.Y - 154;
+                rectangHeight += 154;
+            }
+            else
+            {
+                rectangHeight += mobOrigin.Y;
+            }
+
+            if (sourceBmp.Height - mobOrigin.Y > 18)
+            {
+                rectangHeight += 18;
+            }
+            else
+            {
+                rectangHeight += sourceBmp.Height - mobOrigin.Y;
+            }
+
+            xOffset = rectangXoffset == 0 ? xOffset : 53;
+            yOffset = rectangYoffset == 0 ? yOffset : 46;
+
+            return sourceBmp.Clone(new Rectangle(rectangXoffset, rectangYoffset, rectangWidth, rectangHeight), sourceBmp.PixelFormat);
+        }
+    }
+}

--- a/WzComparerR2/CharaSimControl/GearTooltipRender22.cs
+++ b/WzComparerR2/CharaSimControl/GearTooltipRender22.cs
@@ -1242,7 +1242,7 @@ namespace WzComparerR2.CharaSimControl
                 secondLineNeeded = false;
                 hasThirdContents = true;
 
-                TextRenderer.DrawText(g, $"데미지 상한 돌파량 {ItemStringHelper.ToChineseNumberExpr(value)}", GearGraphics.EquipMDMoris9Font, new Point(15, picH), ((SolidBrush)GearGraphics.GreenBrush2).Color, TextFormatFlags.NoPadding);
+                TextRenderer.DrawText(g, $"데미지 상한 돌파량 {ItemStringHelper.ToCJKNumberExpr(value)}", GearGraphics.EquipMDMoris9Font, new Point(15, picH), ((SolidBrush)GearGraphics.GreenBrush2).Color, TextFormatFlags.NoPadding);
                 picH += 16;
                 picH += 4;
             }

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -63,6 +63,7 @@ namespace WzComparerR2.CharaSimControl
         public TooltipRender LinkRecipeGearRender { get; set; }
         public TooltipRender LinkRecipeItemRender { get; set; }
         public TooltipRender LinkDamageSkinRender { get; set; }
+        public TooltipRender FamiliarRender { get; set; }
         public TooltipRender SetItemRender { get; set; }
         public TooltipRender CashPackageRender { get; set; }
         private AvatarCanvasManager avatar { get; set; }
@@ -236,6 +237,15 @@ namespace WzComparerR2.CharaSimControl
                 if (damageSkin != null)
                 {
                     setItemBmp = RenderDamageSkin(damageSkin);
+                }
+            }
+            
+            if (this.item.FamiliarID != null)
+            {
+                Familiar familiar = Familiar.CreateFromNode(PluginManager.FindWz($@"Character\Familiar\{item.FamiliarID}.img"), PluginManager.FindWz);
+                if (familiar != null)
+                {
+                    return RenderFamiliar(familiar);
                 }
             }
 
@@ -1147,6 +1157,24 @@ namespace WzComparerR2.CharaSimControl
                 defaultRenderer.DamageSkin = damageSkin;
             }
             renderer.TargetItem = damageSkin;
+            return renderer.Render();
+        }
+
+        private Bitmap RenderFamiliar(Familiar familiar)
+        {
+            TooltipRender renderer = this.FamiliarRender;
+            if (renderer == null)
+            {
+                FamiliarTooltipRender defaultRenderer = new FamiliarTooltipRender();
+                defaultRenderer.StringLinker = this.StringLinker;
+                defaultRenderer.ShowObjectID = this.ShowObjectID;
+                defaultRenderer.AllowOutOfBounds = false;
+                defaultRenderer.ItemID = this.item.ItemID;
+                defaultRenderer.FamiliarTier = this.item.Grade;
+                defaultRenderer.UseAssembleUI = false;
+                renderer = defaultRenderer;
+            }
+            renderer.TargetItem = familiar;
             return renderer.Render();
         }
 

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -232,7 +232,7 @@ namespace WzComparerR2.CharaSimControl
 
             if (this.item.DamageSkinID != null && ShowDamageSkin)
             {
-                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
+                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz) ?? DamageSkin.CreateFromNode(PluginManager.FindWz($@"Effect\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
                 if (damageSkin != null)
                 {
                     setItemBmp = RenderDamageSkin(damageSkin);

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender2.cs
@@ -49,6 +49,12 @@ namespace WzComparerR2.CharaSimControl
         public bool CompareMode { get; set; } = false;
         public int CosmeticHairColor { get; set; }
         public int CosmeticFaceColor { get; set; }
+        public bool ShowDamageSkin { get; set; }
+        public bool ShowDamageSkinID { get; set; }
+        public bool UseMiniSizeDamageSkin { get; set; }
+        public bool AlwaysUseMseaFormatDamageSkin { get; set; }
+        public bool DisplayUnitOnSingleLine { get; set; }
+        public long DamageSkinNumber { get; set; }
         private bool WillDrawNickTag { get; set; }
         private Wz_Node NickResNode { get; set; }
         private Bitmap ItemSample { get; set; }
@@ -56,6 +62,7 @@ namespace WzComparerR2.CharaSimControl
         public TooltipRender LinkRecipeInfoRender { get; set; }
         public TooltipRender LinkRecipeGearRender { get; set; }
         public TooltipRender LinkRecipeItemRender { get; set; }
+        public TooltipRender LinkDamageSkinRender { get; set; }
         public TooltipRender SetItemRender { get; set; }
         public TooltipRender CashPackageRender { get; set; }
         private AvatarCanvasManager avatar { get; set; }
@@ -220,6 +227,15 @@ namespace WzComparerR2.CharaSimControl
                 else if (CharaSimLoader.LoadedSetItems.TryGetValue((int)setID, out setItem))
                 {
                     setItemBmp = RenderSetItem(setItem);
+                }
+            }
+
+            if (this.item.DamageSkinID != null && ShowDamageSkin)
+            {
+                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
+                if (damageSkin != null)
+                {
+                    setItemBmp = RenderDamageSkin(damageSkin);
                 }
             }
 
@@ -1113,6 +1129,25 @@ namespace WzComparerR2.CharaSimControl
             }
 
             return tags;
+        }
+
+        private Bitmap RenderDamageSkin(DamageSkin damageSkin)
+        {
+            TooltipRender renderer = this.LinkDamageSkinRender;
+            if (renderer == null)
+            {
+                DamageSkinTooltipRenderer defaultRenderer = new DamageSkinTooltipRenderer();
+                defaultRenderer.StringLinker = this.StringLinker;
+                defaultRenderer.ShowObjectID = this.ShowDamageSkinID;
+                defaultRenderer.UseMiniSize = this.UseMiniSizeDamageSkin;
+                defaultRenderer.AlwaysUseMseaFormat = this.AlwaysUseMseaFormatDamageSkin;
+                defaultRenderer.DisplayUnitOnSingleLine = this.DisplayUnitOnSingleLine;
+                defaultRenderer.DamageSkinNumber = this.DamageSkinNumber;
+                renderer = defaultRenderer;
+                defaultRenderer.DamageSkin = damageSkin;
+            }
+            renderer.TargetItem = damageSkin;
+            return renderer.Render();
         }
 
         private Bitmap RenderLinkRecipeInfo(Recipe recipe)

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
@@ -233,7 +233,7 @@ namespace WzComparerR2.CharaSimControl
 
             if (this.item.DamageSkinID != null && ShowDamageSkin)
             {
-                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
+                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz) ?? DamageSkin.CreateFromNode(PluginManager.FindWz($@"Effect\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
                 if (damageSkin != null)
                 {
                     setItemBmp = RenderDamageSkin(damageSkin);

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
@@ -63,6 +63,7 @@ namespace WzComparerR2.CharaSimControl
         public TooltipRender LinkRecipeGearRender { get; set; }
         public TooltipRender LinkRecipeItemRender { get; set; }
         public TooltipRender LinkDamageSkinRender { get; set; }
+        public TooltipRender FamiliarRender { get; set; }
         public TooltipRender SetItemRender { get; set; }
         public TooltipRender CashPackageRender { get; set; }
         private AvatarCanvasManager avatar { get; set; }
@@ -237,6 +238,15 @@ namespace WzComparerR2.CharaSimControl
                 if (damageSkin != null)
                 {
                     setItemBmp = RenderDamageSkin(damageSkin);
+                }
+            }
+
+            if (this.item.FamiliarID != null)
+            {
+                Familiar familiar = Familiar.CreateFromNode(PluginManager.FindWz($@"Character\Familiar\{item.FamiliarID}.img"), PluginManager.FindWz);
+                if (familiar != null)
+                {
+                    return RenderFamiliar(familiar);
                 }
             }
 
@@ -1051,6 +1061,25 @@ namespace WzComparerR2.CharaSimControl
             renderer.TargetItem = damageSkin;
             return renderer.Render();
         }
+
+        private Bitmap RenderFamiliar(Familiar familiar)
+        {
+            TooltipRender renderer = this.FamiliarRender;
+            if (renderer == null)
+            {
+                FamiliarTooltipRender defaultRenderer = new FamiliarTooltipRender();
+                defaultRenderer.StringLinker = this.StringLinker;
+                defaultRenderer.ShowObjectID = this.ShowObjectID;
+                defaultRenderer.AllowOutOfBounds = false;
+                defaultRenderer.ItemID = this.item.ItemID;
+                defaultRenderer.FamiliarTier = this.item.Grade;
+                defaultRenderer.UseAssembleUI = false;
+                renderer = defaultRenderer;
+            }
+            renderer.TargetItem = familiar;
+            return renderer.Render();
+        }
+
 
         private List<string> GetItemBottomAttributeString(StringResult sr)
         {

--- a/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
+++ b/WzComparerR2/CharaSimControl/ItemTooltipRender22.cs
@@ -49,6 +49,12 @@ namespace WzComparerR2.CharaSimControl
         public bool CompareMode { get; set; } = false;
         public int CosmeticHairColor { get; set; }
         public int CosmeticFaceColor { get; set; }
+        public bool ShowDamageSkin { get; set; }
+        public bool ShowDamageSkinID { get; set; }
+        public bool UseMiniSizeDamageSkin { get; set; }
+        public bool AlwaysUseMseaFormatDamageSkin { get; set; }
+        public bool DisplayUnitOnSingleLine { get; set; }
+        public long DamageSkinNumber { get; set; }
         private bool WillDrawNickTag { get; set; }
         private Wz_Node NickResNode { get; set; }
         private Bitmap ItemSample { get; set; }
@@ -56,6 +62,7 @@ namespace WzComparerR2.CharaSimControl
         public TooltipRender LinkRecipeInfoRender { get; set; }
         public TooltipRender LinkRecipeGearRender { get; set; }
         public TooltipRender LinkRecipeItemRender { get; set; }
+        public TooltipRender LinkDamageSkinRender { get; set; }
         public TooltipRender SetItemRender { get; set; }
         public TooltipRender CashPackageRender { get; set; }
         private AvatarCanvasManager avatar { get; set; }
@@ -221,6 +228,15 @@ namespace WzComparerR2.CharaSimControl
                 else if (CharaSimLoader.LoadedSetItems.TryGetValue((int)setID, out setItem))
                 {
                     setItemBmp = RenderSetItem(setItem);
+                }
+            }
+
+            if (this.item.DamageSkinID != null && ShowDamageSkin)
+            {
+                DamageSkin damageSkin = DamageSkin.CreateFromNode(PluginManager.FindWz($@"Etc\DamageSkin.img\{item.DamageSkinID}", this.SourceWzFile), PluginManager.FindWz);
+                if (damageSkin != null)
+                {
+                    setItemBmp = RenderDamageSkin(damageSkin);
                 }
             }
 
@@ -1015,6 +1031,25 @@ namespace WzComparerR2.CharaSimControl
             }
 
             return tags;
+        }
+
+        private Bitmap RenderDamageSkin(DamageSkin damageSkin)
+        {
+            TooltipRender renderer = this.LinkDamageSkinRender;
+            if (renderer == null)
+            {
+                DamageSkinTooltipRenderer defaultRenderer = new DamageSkinTooltipRenderer();
+                defaultRenderer.StringLinker = this.StringLinker;
+                defaultRenderer.ShowObjectID = this.ShowDamageSkinID;
+                defaultRenderer.UseMiniSize = this.UseMiniSizeDamageSkin;
+                defaultRenderer.AlwaysUseMseaFormat = this.AlwaysUseMseaFormatDamageSkin;
+                defaultRenderer.DisplayUnitOnSingleLine = this.DisplayUnitOnSingleLine;
+                defaultRenderer.DamageSkinNumber = this.DamageSkinNumber;
+                renderer = defaultRenderer;
+                defaultRenderer.DamageSkin = damageSkin;
+            }
+            renderer.TargetItem = damageSkin;
+            return renderer.Render();
         }
 
         private List<string> GetItemBottomAttributeString(StringResult sr)

--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -816,6 +816,12 @@ namespace WzComparerR2.Comparer
                     tooltipRenderNewOld[i].SourceWzFile = WzFileNewOld[i];
                     (tooltipRenderNewOld[i] as ItemTooltipRender22).CosmeticHairColor = CharaSimConfig.Default.Item.CosmeticHairColor;
                     (tooltipRenderNewOld[i] as ItemTooltipRender22).CosmeticFaceColor = CharaSimConfig.Default.Item.CosmeticFaceColor;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).ShowDamageSkin = CharaSimConfig.Default.DamageSkin.ShowDamageSkin;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).ShowDamageSkinID = CharaSimConfig.Default.DamageSkin.ShowDamageSkinID;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).UseMiniSizeDamageSkin = CharaSimConfig.Default.DamageSkin.UseMiniSize;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).AlwaysUseMseaFormatDamageSkin = CharaSimConfig.Default.DamageSkin.AlwaysUseMseaFormat;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).DisplayUnitOnSingleLine = CharaSimConfig.Default.DamageSkin.DisplayUnitOnSingleLine;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender22).DamageSkinNumber = CharaSimConfig.Default.DamageSkin.DamageSkinNumber;
                 }
                 else
                 {
@@ -829,6 +835,12 @@ namespace WzComparerR2.Comparer
                     tooltipRenderNewOld[i].SourceWzFile = WzFileNewOld[i];
                     (tooltipRenderNewOld[i] as ItemTooltipRender2).CosmeticHairColor = CharaSimConfig.Default.Item.CosmeticHairColor;
                     (tooltipRenderNewOld[i] as ItemTooltipRender2).CosmeticFaceColor = CharaSimConfig.Default.Item.CosmeticFaceColor;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).ShowDamageSkin = CharaSimConfig.Default.DamageSkin.ShowDamageSkin;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).ShowDamageSkinID = CharaSimConfig.Default.DamageSkin.ShowDamageSkinID;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).UseMiniSizeDamageSkin = CharaSimConfig.Default.DamageSkin.UseMiniSize;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).AlwaysUseMseaFormatDamageSkin = CharaSimConfig.Default.DamageSkin.AlwaysUseMseaFormat;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).DisplayUnitOnSingleLine = CharaSimConfig.Default.DamageSkin.DisplayUnitOnSingleLine;
+                    (tooltipRenderNewOld[i] as ItemTooltipRender2).DamageSkinNumber = CharaSimConfig.Default.DamageSkin.DamageSkinNumber;
                 }
             }
 

--- a/WzComparerR2/Config/CharaSimConfig.cs
+++ b/WzComparerR2/Config/CharaSimConfig.cs
@@ -29,6 +29,12 @@ namespace WzComparerR2.Config
             get { return (CharaSimSkillConfig)this["skill"]; }
         }
 
+        [ConfigurationProperty("damageSkin")]
+        public CharaSimDamageSkinConfig DamageSkin
+        {
+            get { return (CharaSimDamageSkinConfig)this["damageSkin"]; }
+        }
+
         [ConfigurationProperty("gear")]
         public CharaSimGearConfig Gear
         {

--- a/WzComparerR2/Config/CharaSimDamageSkinConfig.cs
+++ b/WzComparerR2/Config/CharaSimDamageSkinConfig.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Configuration;
+
+namespace WzComparerR2.Config
+{
+    public class CharaSimDamageSkinConfig : ConfigurationElement
+    {
+        [ConfigurationProperty("showDamageSkinID", DefaultValue = true)]
+        public bool ShowDamageSkinID
+        {
+            get { return (bool)this["showDamageSkinID"]; }
+            set { this["showDamageSkinID"] = value; }
+        }
+
+        [ConfigurationProperty("showDamageSkin", DefaultValue = true)]
+        public bool ShowDamageSkin
+        {
+            get { return (bool)this["showDamageSkin"]; }
+            set { this["showDamageSkin"] = value; }
+        }
+
+        [ConfigurationProperty("useMiniSize", DefaultValue = false)]
+        public bool UseMiniSize
+        {
+            get { return (bool)this["useMiniSize"]; }
+            set { this["useMiniSize"] = value; }
+        }
+
+        [ConfigurationProperty("alwaysUseMseaFormat", DefaultValue = false)]
+        public bool AlwaysUseMseaFormat
+        {
+            get { return (bool)this["alwaysUseMseaFormat"]; }
+            set { this["alwaysUseMseaFormat"] = value; }
+        }
+
+        [ConfigurationProperty("displayUnitOnSingleLine", DefaultValue = false)]
+        public bool DisplayUnitOnSingleLine
+        {
+            get { return (bool)this["displayUnitOnSingleLine"]; }
+            set { this["displayUnitOnSingleLine"] = value; }
+        }
+
+        [ConfigurationProperty("damageSkinNumber", DefaultValue = (long)1234567890)]
+        public long DamageSkinNumber
+        {
+            get { return (long)this["damageSkinNumber"]; }
+            set { this["damageSkinNumber"] = value; }
+        }
+    }
+}

--- a/WzComparerR2/FrmQuickViewSetting.Designer.cs
+++ b/WzComparerR2/FrmQuickViewSetting.Designer.cs
@@ -76,11 +76,20 @@
             this.superTabControlPanel5 = new DevComponents.DotNetBar.SuperTabControlPanel();
             this.superTabControlPanel6 = new DevComponents.DotNetBar.SuperTabControlPanel();
             this.superTabControlPanel7 = new DevComponents.DotNetBar.SuperTabControlPanel();
+            this.superTabControlPanel8 = new DevComponents.DotNetBar.SuperTabControlPanel();
+            this.chkShowDamageSkinID = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkShowDamageSkin = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkUseMiniSize = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkAlwaysUseMseaFormat = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkDisplayUnitOnSingleLine = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.lblDamageSkinNumber = new DevComponents.DotNetBar.LabelX();
+            this.txtDamageSkinNumber = new DevComponents.DotNetBar.Controls.TextBoxX();
             this.checkBoxX7 = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.superTabItem4 = new DevComponents.DotNetBar.SuperTabItem();
             this.superTabItem5 = new DevComponents.DotNetBar.SuperTabItem();
             this.superTabItem6 = new DevComponents.DotNetBar.SuperTabItem();
             this.superTabItem7 = new DevComponents.DotNetBar.SuperTabItem();
+            this.superTabItem8 = new DevComponents.DotNetBar.SuperTabItem();
             this.panelEx1 = new DevComponents.DotNetBar.PanelEx();
             this.buttonX2 = new DevComponents.DotNetBar.ButtonX();
             this.buttonX1 = new DevComponents.DotNetBar.ButtonX();
@@ -105,6 +114,7 @@
             this.superTabControlPanel5.SuspendLayout();
             this.superTabControlPanel6.SuspendLayout();
             this.superTabControlPanel7.SuspendLayout();
+            this.superTabControlPanel8.SuspendLayout();
             this.panelEx1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -130,6 +140,7 @@
             this.superTabControl1.Controls.Add(this.superTabControlPanel2);
             this.superTabControl1.Controls.Add(this.superTabControlPanel3);
             this.superTabControl1.Controls.Add(this.superTabControlPanel4);
+            this.superTabControl1.Controls.Add(this.superTabControlPanel8);
             this.superTabControl1.Controls.Add(this.superTabControlPanel6);
             this.superTabControl1.Controls.Add(this.superTabControlPanel7);
             this.superTabControl1.Controls.Add(this.superTabControlPanel5);
@@ -149,6 +160,7 @@
             this.superTabItem2,
             this.superTabItem3,
             this.superTabItem4,
+            this.superTabItem8,
             this.superTabItem6,
             this.superTabItem7,
             this.superTabItem5});
@@ -953,6 +965,135 @@
             this.labelXQSHint.Size = new System.Drawing.Size(236, 30);
             this.labelXQSHint.TabIndex = 3;
             this.labelXQSHint.Text = "퀘스트 상태 변경 <b>- +</b> 또는 <b>← →</b> <br/> 상태 0 : 시작 가능 <br/> 상태 1 : 진행 중 <br/> 상태 2 : 완료";
+
+            // 
+            // superTabControlPanel8
+            // 
+            this.superTabControlPanel8.Controls.Add(this.txtDamageSkinNumber);
+            this.superTabControlPanel8.Controls.Add(this.lblDamageSkinNumber);
+            this.superTabControlPanel8.Controls.Add(this.chkDisplayUnitOnSingleLine);
+            this.superTabControlPanel8.Controls.Add(this.chkAlwaysUseMseaFormat);
+            this.superTabControlPanel8.Controls.Add(this.chkUseMiniSize);
+            this.superTabControlPanel8.Controls.Add(this.chkShowDamageSkin);
+            this.superTabControlPanel8.Controls.Add(this.chkShowDamageSkinID);
+            this.superTabControlPanel8.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.superTabControlPanel8.Location = new System.Drawing.Point(62, 0);
+            this.superTabControlPanel8.Name = "superTabControlPanel8";
+            this.superTabControlPanel8.Size = new System.Drawing.Size(242, 211);
+            this.superTabControlPanel8.TabIndex = 0;
+            this.superTabControlPanel8.TabItem = this.superTabItem8;
+            this.superTabControlPanel8.Visible = false;
+            // 
+            // superTabItem8
+            // 
+            this.superTabItem8.AttachedControl = this.superTabControlPanel8;
+            this.superTabItem8.GlobalItem = false;
+            this.superTabItem8.Name = "superTabItem8";
+            this.superTabItem8.Text = "데미지 스킨";
+            // 
+            // txtDamageSkinNumber
+            // 
+            // 
+            // 
+            // 
+            this.txtDamageSkinNumber.Border.Class = "TextBoxBorder";
+            this.txtDamageSkinNumber.Border.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.txtDamageSkinNumber.Location = new System.Drawing.Point(86, 130);
+            this.txtDamageSkinNumber.Name = "txtDamageSkinNumber";
+            this.txtDamageSkinNumber.Size = new System.Drawing.Size(160, 23);
+            this.txtDamageSkinNumber.WatermarkText = "1234567890";
+            this.txtDamageSkinNumber.MaxLength = 18;
+            this.txtDamageSkinNumber.TextChanged += new System.EventHandler(this.txtDamageSkinNumber_TextChanged);
+            this.txtDamageSkinNumber.TabIndex = 7;
+            // 
+            // lblDamageSkinNumber
+            // 
+            this.lblDamageSkinNumber.AutoSize = true;
+            this.lblDamageSkinNumber.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.lblDamageSkinNumber.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.lblDamageSkinNumber.Location = new System.Drawing.Point(13, 132);
+            this.lblDamageSkinNumber.Name = "lblDamageSkinNumber";
+            this.lblDamageSkinNumber.Size = new System.Drawing.Size(87, 16);
+            this.lblDamageSkinNumber.TabIndex = 6;
+            this.lblDamageSkinNumber.Text = "데미지 숫자";
+            // 
+            // chkDisplayUnitOnSingleLine
+            // 
+            this.chkDisplayUnitOnSingleLine.AutoSize = true;
+            this.chkDisplayUnitOnSingleLine.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkDisplayUnitOnSingleLine.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkDisplayUnitOnSingleLine.Location = new System.Drawing.Point(13, 108);
+            this.chkDisplayUnitOnSingleLine.Name = "chkDisplayUnitOnSingleLine";
+            this.chkDisplayUnitOnSingleLine.Size = new System.Drawing.Size(133, 16);
+            this.chkDisplayUnitOnSingleLine.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkDisplayUnitOnSingleLine.TabIndex = 5;
+            this.chkDisplayUnitOnSingleLine.Text = "단위를 다른 행에 표시";
+            // 
+            // chkAlwaysUseMseaFormat
+            // 
+            this.chkAlwaysUseMseaFormat.AutoSize = true;
+            this.chkAlwaysUseMseaFormat.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkAlwaysUseMseaFormat.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkAlwaysUseMseaFormat.Location = new System.Drawing.Point(13, 84);
+            this.chkAlwaysUseMseaFormat.Name = "chkAlwaysUseMseaFormat";
+            this.chkAlwaysUseMseaFormat.Size = new System.Drawing.Size(133, 16);
+            this.chkAlwaysUseMseaFormat.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkAlwaysUseMseaFormat.TabIndex = 4;
+            this.chkAlwaysUseMseaFormat.Text = "MSEA의 3자리 구분 기호 사용";
+            // 
+            // chkUseMiniSize
+            // 
+            this.chkUseMiniSize.AutoSize = true;
+            this.chkUseMiniSize.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkUseMiniSize.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkUseMiniSize.Location = new System.Drawing.Point(13, 60);
+            this.chkUseMiniSize.Name = "chkUseMiniSize";
+            this.chkUseMiniSize.Size = new System.Drawing.Size(145, 16);
+            this.chkUseMiniSize.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkUseMiniSize.TabIndex = 3;
+            this.chkUseMiniSize.Text = "데미지 스킨의 미니 사이즈 사용";
+            // 
+            // chkShowDamageSkin
+            // 
+            this.chkShowDamageSkin.AutoSize = true;
+            this.chkShowDamageSkin.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkShowDamageSkin.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkShowDamageSkin.Location = new System.Drawing.Point(13, 36);
+            this.chkShowDamageSkin.Name = "chkShowDamageSkin";
+            this.chkShowDamageSkin.Size = new System.Drawing.Size(172, 16);
+            this.chkShowDamageSkin.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkShowDamageSkin.TabIndex = 2;
+            this.chkShowDamageSkin.Text = "데미지 스킨 표시";
+            // 
+            // chkShowDamageSkinID
+            // 
+            this.chkShowDamageSkinID.AutoSize = true;
+            this.chkShowDamageSkinID.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkShowDamageSkinID.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkShowDamageSkinID.Location = new System.Drawing.Point(13, 12);
+            this.chkShowDamageSkinID.Name = "chkShowDamageSkinID";
+            this.chkShowDamageSkinID.Size = new System.Drawing.Size(117, 16);
+            this.chkShowDamageSkinID.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkShowDamageSkinID.TabIndex = 1;
+            this.chkShowDamageSkinID.Text = "데미지 스킨 코드 표시";
             // 
             // superTabControlPanel5
             // 
@@ -1044,6 +1185,8 @@
             this.superTabControlPanel6.PerformLayout();
             this.superTabControlPanel7.ResumeLayout(false);
             this.superTabControlPanel7.PerformLayout();
+            this.superTabControlPanel8.ResumeLayout(false);
+            this.superTabControlPanel8.PerformLayout();
             this.panelEx1.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -1080,15 +1223,19 @@
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX3;
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX5;
         private DevComponents.DotNetBar.LabelX labelX3;
+        private DevComponents.DotNetBar.LabelX lblDamageSkinNumber;
+        private DevComponents.DotNetBar.Controls.TextBoxX txtDamageSkinNumber;
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX4;
         private DevComponents.DotNetBar.SuperTabControlPanel superTabControlPanel4;
         private DevComponents.DotNetBar.SuperTabControlPanel superTabControlPanel5;
         private DevComponents.DotNetBar.SuperTabControlPanel superTabControlPanel6;
         private DevComponents.DotNetBar.SuperTabControlPanel superTabControlPanel7;
+        private DevComponents.DotNetBar.SuperTabControlPanel superTabControlPanel8;
         private DevComponents.DotNetBar.SuperTabItem superTabItem4;
         private DevComponents.DotNetBar.SuperTabItem superTabItem5;
         private DevComponents.DotNetBar.SuperTabItem superTabItem6;
         private DevComponents.DotNetBar.SuperTabItem superTabItem7;
+        private DevComponents.DotNetBar.SuperTabItem superTabItem8;
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX6;
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX7;
         private DevComponents.DotNetBar.Controls.CheckBoxX checkBoxX9;
@@ -1105,6 +1252,11 @@
         private DevComponents.DotNetBar.LabelX labelCosmeticHairColor;
         private DevComponents.DotNetBar.LabelX labelCosmeticFaceColor;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkEnable22AniStyle;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkinID;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkin;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkUseMiniSize;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkAlwaysUseMseaFormat;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkDisplayUnitOnSingleLine;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowMiniMap;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowMiniMapMob;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowMiniMapNpc;

--- a/WzComparerR2/FrmQuickViewSetting.cs
+++ b/WzComparerR2/FrmQuickViewSetting.cs
@@ -150,6 +150,48 @@ namespace WzComparerR2
         }
 
         [Link]
+        public bool DamageSkin_ShowDamageSkinID
+        {
+            get { return chkShowDamageSkinID.Checked; }
+            set { chkShowDamageSkinID.Checked = value; }
+        }
+
+        [Link]
+        public bool DamageSkin_ShowDamageSkin
+        {
+            get { return chkShowDamageSkin.Checked; }
+            set { chkShowDamageSkin.Checked = value; }
+        }
+
+        [Link]
+        public bool DamageSkin_UseMiniSize
+        {
+            get { return chkUseMiniSize.Checked; }
+            set { chkUseMiniSize.Checked = value; }
+        }
+
+        [Link]
+        public bool DamageSkin_AlwaysUseMseaFormat
+        {
+            get { return chkAlwaysUseMseaFormat.Checked; }
+            set { chkAlwaysUseMseaFormat.Checked = value; }
+        }
+
+        [Link]
+        public bool DamageSkin_DisplayUnitOnSingleLine
+        {
+            get { return chkDisplayUnitOnSingleLine.Checked; }
+            set { chkDisplayUnitOnSingleLine.Checked = value; }
+        }
+
+        [Link]
+        public long DamageSkin_DamageSkinNumber
+        {
+            get { return long.TryParse(txtDamageSkinNumber.Text, out long val) ? val : 0; }
+            set { txtDamageSkinNumber.Text = value.ToString(); }
+        }
+
+        [Link]
         public bool Gear_ShowLevelOrSealed
         {
             get { return checkBoxX6.Checked; }
@@ -319,6 +361,22 @@ namespace WzComparerR2
             this.comboBoxExQuestState.Enabled = !this.chkQAS.Checked;
             this.labelXQS.Enabled = !this.chkQAS.Checked;
             this.labelXQSHint.Enabled = !this.chkQAS.Checked;
+        }
+
+
+
+        private void txtDamageSkinNumber_TextChanged(object sender, EventArgs e)
+        {
+            this.buttonX1.Enabled = !(string.IsNullOrEmpty(txtDamageSkinNumber.Text) || txtDamageSkinNumber.Text == "0");
+
+            string digitsOnly = new string(txtDamageSkinNumber.Text.Where(char.IsDigit).ToArray());
+
+            if (txtDamageSkinNumber.Text != digitsOnly)
+            {
+                int cursorPos = txtDamageSkinNumber.SelectionStart;
+                txtDamageSkinNumber.Text = digitsOnly;
+                txtDamageSkinNumber.SelectionStart = Math.Min(cursorPos, txtDamageSkinNumber.Text.Length);
+            }
         }
 
         private sealed class LinkAttribute : Attribute

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -254,7 +254,7 @@ namespace WzComparerR2
 
             this.skillDefaultLevel = Setting.Skill.DefaultLevel;
             this.skillInterval = Setting.Skill.IntervalLevel;
-
+            tooltipQuickView.FamiliarRender.ShowObjectID = Setting.Gear.ShowID;
             tooltipQuickView.GearRender.ShowObjectID = Setting.Gear.ShowID;
             tooltipQuickView.GearRender.ShowSpeed = Setting.Gear.ShowWeaponSpeed;
             tooltipQuickView.GearRender.ShowLevelOrSealed = Setting.Gear.ShowLevelOrSealed;
@@ -3481,13 +3481,25 @@ namespace WzComparerR2
                     CharaSimLoader.LoadSetItemsIfEmpty();
                     CharaSimLoader.LoadExclusiveEquipsIfEmpty();
                     CharaSimLoader.LoadCommoditiesIfEmpty();
-                    var gear = Gear.CreateFromNode(image.Node, PluginManager.FindWz);
-                    obj = gear;
-                    if (gear != null)
+                    if (selectedNode.FullPathToFile.Contains("Familiar"))
                     {
-                        fileName = gear.ItemID + ".png";
+                        var familiar = Familiar.CreateFromNode(image.Node, PluginManager.FindWz);
+                        obj = familiar;
+                        if (familiar != null)
+                        {
+                            fileName = "familiar_" + familiar.FamiliarID + ".png";
+                        }
                     }
-                    break;
+                    else
+                    {
+                        var gear = Gear.CreateFromNode(image.Node, PluginManager.FindWz);
+                        obj = gear;
+                        if (gear != null)
+                        {
+                            fileName = gear.ItemID + ".png";
+                        }
+                    }
+                        break;
                 case Wz_Type.Item:
                     CharaSimLoader.LoadCommoditiesIfEmpty();
                     Wz_Node itemNode = selectedNode;

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -272,12 +272,24 @@ namespace WzComparerR2
             tooltipQuickView.ItemRender.ShowLevelOrSealed = Setting.Gear.ShowLevelOrSealed;
             tooltipQuickView.ItemRender.CosmeticHairColor = Setting.Item.CosmeticHairColor;
             tooltipQuickView.ItemRender.CosmeticFaceColor = Setting.Item.CosmeticFaceColor;
+            tooltipQuickView.ItemRender.ShowDamageSkin = Setting.DamageSkin.ShowDamageSkin;
+            tooltipQuickView.ItemRender.ShowDamageSkinID = Setting.DamageSkin.ShowDamageSkinID;
+            tooltipQuickView.ItemRender.UseMiniSizeDamageSkin = Setting.DamageSkin.UseMiniSize;
+            tooltipQuickView.ItemRender.AlwaysUseMseaFormatDamageSkin = Setting.DamageSkin.AlwaysUseMseaFormat;
+            tooltipQuickView.ItemRender.DisplayUnitOnSingleLine = Setting.DamageSkin.DisplayUnitOnSingleLine;
+            tooltipQuickView.ItemRender.DamageSkinNumber = Setting.DamageSkin.DamageSkinNumber;
             tooltipQuickView.ItemRender22.ShowObjectID = Setting.Item.ShowID;
             tooltipQuickView.ItemRender22.LinkRecipeInfo = Setting.Item.LinkRecipeInfo;
             tooltipQuickView.ItemRender22.LinkRecipeItem = Setting.Item.LinkRecipeItem;
             tooltipQuickView.ItemRender22.ShowLevelOrSealed = Setting.Gear.ShowLevelOrSealed;
             tooltipQuickView.ItemRender22.CosmeticHairColor = Setting.Item.CosmeticHairColor;
             tooltipQuickView.ItemRender22.CosmeticFaceColor = Setting.Item.CosmeticFaceColor;
+            tooltipQuickView.ItemRender22.ShowDamageSkin = Setting.DamageSkin.ShowDamageSkin;
+            tooltipQuickView.ItemRender22.ShowDamageSkinID = Setting.DamageSkin.ShowDamageSkinID;
+            tooltipQuickView.ItemRender22.UseMiniSizeDamageSkin = Setting.DamageSkin.UseMiniSize;
+            tooltipQuickView.ItemRender22.AlwaysUseMseaFormatDamageSkin = Setting.DamageSkin.AlwaysUseMseaFormat;
+            tooltipQuickView.ItemRender22.DisplayUnitOnSingleLine = Setting.DamageSkin.DisplayUnitOnSingleLine;
+            tooltipQuickView.ItemRender22.DamageSkinNumber = Setting.DamageSkin.DamageSkinNumber;
 
             tooltipQuickView.MapRender.ShowMiniMap = Setting.Map.ShowMiniMap;
             tooltipQuickView.MapRender.ShowMiniMapMob = Setting.Map.ShowMiniMapMob;


### PR DESCRIPTION
This feature is ported from JMS fork to add preview of damage skin. It supports following damage skin types:

1. General (without units)
<img width="994" height="194" alt="image" src="https://github.com/user-attachments/assets/0286f285-ec3f-49a2-a01b-0a6e65bb8d16" />

2. hangul
<img width="1420" height="228" alt="image" src="https://github.com/user-attachments/assets/42f7a6b0-2b09-4259-8ac2-f8a54f756c3b" />

3. hangulUnit (KMS, CMS, TMS, JMS)
<img width="1271" height="324" alt="image" src="https://github.com/user-attachments/assets/cf74bb6e-7a58-42be-8505-a9635d61807a" />

4. glUnit (GMS)
<img width="1213" height="324" alt="image" src="https://github.com/user-attachments/assets/39dc1f6f-ca62-4a1c-9857-45f652846951" />

5. glUnit2 (MSEA)
<img width="1306" height="324" alt="image" src="https://github.com/user-attachments/assets/8fdcba38-9076-4f5e-9cd4-7965ba65e913" />

You may also choose to display all available units on a separated line.
<img width="1213" height="327" alt="image" src="https://github.com/user-attachments/assets/41c128fc-34f7-4b26-bb70-258cf2938f5f" />

<img width="1213" height="328" alt="image" src="https://github.com/user-attachments/assets/a9399982-5e8b-47cf-8440-db8b19ab47db" />

Since certain damage skins have added "T / 조" (at least in CMS and TMS), placeholder units were added in case "T / 조" and "Q / 경" are missing in selected damage skin. Placeholder units will not be displayed when you choose to display units on a separated line. Check https://github.com/seotbeo/CharaSimResource/pull/1 for placeholder units.
<img width="1463" height="351" alt="image" src="https://github.com/user-attachments/assets/a5775281-3008-4383-874d-71415842fbfc" />

<img width="1919" height="324" alt="image" src="https://github.com/user-attachments/assets/94f3294d-32ac-423d-8a5d-a3c827ee7d64" />

<img width="1885" height="324" alt="image" src="https://github.com/user-attachments/assets/c53a32a0-0a25-41f0-ada4-b5bbbbada04e" />
