### PR TITLE
Port NPC Illust Preview feature from JMS fork

### DIFF
--- a/WzComparerR2.Common/CharaSim/Npc.cs
+++ b/WzComparerR2.Common/CharaSim/Npc.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Text;
 using System.Text.RegularExpressions;
 using WzComparerR2.WzLib;
@@ -12,14 +13,36 @@ namespace WzComparerR2.CharaSim
         {
             this.ID = -1;
             //this.Animates = new LifeAnimateCollection();
+            this.Illustration2Bitmaps = new List<Bitmap>();
+            this.Illustration2BaseBitmap = null;
+            this.illustIndex = 0;
         }
 
         public int ID { get; set; }
         public bool Shop { get; set; }
 
         public int? Link { get; set; }
+        private int illustIndex;
+
+        public int IllustIndex
+        {
+            get { return illustIndex; }
+            set
+            {
+                if (this.Illustration2Bitmaps.Count == 0)
+                {
+                    illustIndex = 0;
+                }
+                else
+                {
+                    illustIndex = Math.Max(0, Math.Min(value, this.Illustration2Bitmaps.Count - 1));
+                }
+            }
+        }
 
         public BitmapOrigin Default { get; set; }
+        public List<Bitmap> Illustration2Bitmaps { get; set; }
+        public Bitmap Illustration2BaseBitmap { get; set; }
 
         public Wz_Node Component { get; set; }
 
@@ -48,6 +71,8 @@ namespace WzComparerR2.CharaSim
             npcInfo.ID = npcID;
             Wz_Node infoNode = node.FindNodeByPath("info").ResolveUol();
 
+            Point baseOrigin = Point.Empty;
+
             //加载基础属性
             if (infoNode != null)
             {
@@ -59,6 +84,52 @@ namespace WzComparerR2.CharaSim
                         case "link": npcInfo.Link = propNode.GetValueEx<int>(0); break;
                         case "component": npcInfo.Component = propNode; break;
                         case "default": npcInfo.Default = BitmapOrigin.CreateFromNode(propNode, findNode, wzf); break;
+                        case "illustration2":
+                            foreach (var imgNode in propNode.Nodes)
+                            {
+                                switch (imgNode.Text)
+                                {
+                                    case "base":
+                                        var bmpOrigin = BitmapOrigin.CreateFromNode(imgNode, findNode, wzf);
+                                        if (bmpOrigin.Bitmap != null && bmpOrigin.Bitmap.Size != new Size(1, 1))
+                                        {
+                                            npcInfo.Illustration2BaseBitmap = bmpOrigin.Bitmap;
+                                            baseOrigin = bmpOrigin.Origin;
+                                        }
+                                        break;
+                                    case "face":
+                                        foreach (var faceNode in imgNode.Nodes)
+                                        {
+                                            try
+                                            {
+                                                var faceBmpOrigin = BitmapOrigin.CreateFromNode(faceNode, findNode, wzf);
+                                                if (faceBmpOrigin.Bitmap != null && faceBmpOrigin.Bitmap.Size != new Size(1, 1))
+                                                {
+                                                    if (baseOrigin != Point.Empty)
+                                                    {
+                                                        Bitmap combinedBmp = new Bitmap(npcInfo.Illustration2BaseBitmap.Width, npcInfo.Illustration2BaseBitmap.Height);
+                                                        using (Graphics g = Graphics.FromImage(combinedBmp))
+                                                        {
+                                                            g.DrawImageUnscaled(npcInfo.Illustration2BaseBitmap, 0, 0);
+                                                            g.DrawImageUnscaled(faceBmpOrigin.Bitmap, baseOrigin.X - faceBmpOrigin.Origin.X, baseOrigin.Y - faceBmpOrigin.Origin.Y);
+                                                        }
+                                                        npcInfo.Illustration2Bitmaps.Add(combinedBmp);
+                                                    }
+                                                    else
+                                                    {
+                                                        npcInfo.Illustration2Bitmaps.Add(faceBmpOrigin.Bitmap);
+                                                    }
+                                                }
+                                            }
+                                            catch
+                                            {
+                                                continue;
+                                            }
+                                        }
+                                        break;
+                                }
+                            }
+                            break;
                     }
                 }
             }

--- a/WzComparerR2.WzLib/Ms_FileV2.cs
+++ b/WzComparerR2.WzLib/Ms_FileV2.cs
@@ -293,7 +293,7 @@ namespace WzComparerR2.WzLib
                 });
 #else
                 char[] strBuf = new char[strLen];
-                this.ReadBytes(MemoryMarshal.Cast<char, byte>(strBuf));
+                this.ReadBytes(MemoryMarshal.Cast<char, byte>(strBuf.AsSpan()));
                 return new string(strBuf);
 #endif
             }

--- a/WzComparerR2.WzLib/Utilities/WzBinaryReader.cs
+++ b/WzComparerR2.WzLib/Utilities/WzBinaryReader.cs
@@ -132,7 +132,7 @@ namespace WzComparerR2.WzLib.Utilities
                     this.BaseStream.ReadExactly(buffer, 0, size * 2);
                     decrypter.Decrypt(buffer, 0, size * 2);
 
-                    Span<char> chars = MemoryMarshal.Cast<byte, char>(buffer).Slice(0, size);
+                    Span<char> chars = MemoryMarshal.Cast<byte, char>(buffer.AsSpan()).Slice(0, size);
                     // TODO: SIMD optimization for net6
                     ushort mask = 0xAAAA;
                     for (int i = 0; i < size; i++)

--- a/WzComparerR2.WzLib/Wz_Node.cs
+++ b/WzComparerR2.WzLib/Wz_Node.cs
@@ -567,10 +567,25 @@ namespace WzComparerR2.WzLib
             return wzImg;
         }
 
-        public static void DumpAsXml(this Wz_Node node, XmlWriter writer)
+        public static void DumpAsXml(this Wz_Node node, XmlWriter writer) 
+        {
+            DumpAsXml(node, writer, null);
+        }
+
+        public static void DumpAsXml(this Wz_Node node, XmlWriter writer, IList<string> filterTags)
         {
             object value = node.Value;
 
+            // 过滤：根据 tag 名称（类名小写）匹配
+            if (filterTags != null && value != null) {
+                var currentTag = value.GetType().Name.ToLower();  // 例如 "wz_int"
+                foreach (var tag in filterTags) {
+                    if (tag != null && currentTag == tag.Trim().ToLower()) {
+                        return; // 匹配到，跳过输出
+                    }
+                }
+            }
+            
             if (value == null || value is Wz_Image)
             {
                 writer.WriteStartElement("dir");
@@ -663,7 +678,7 @@ namespace WzComparerR2.WzLib
             //输出子节点
             foreach (var child in node.Nodes)
             {
-                DumpAsXml(child, writer);
+                DumpAsXml(child, writer, filterTags);
             }
 
             //结束标识

--- a/WzComparerR2/CharaSimControl/NpcTooltipRenderer.cs
+++ b/WzComparerR2/CharaSimControl/NpcTooltipRenderer.cs
@@ -27,6 +27,7 @@ namespace WzComparerR2.CharaSimControl
         }
 
         public Npc NpcInfo { get; set; }
+        public bool ShowAllIllustAtOnce { get; set; }
         private AvatarCanvasManager avatar { get; set; }
 
         public override Bitmap Render()
@@ -137,6 +138,8 @@ namespace WzComparerR2.CharaSimControl
                 }
             }
 
+            Bitmap illustration2Tooltip = drawIllustration2SetTooltip(NpcInfo.Illustration2Bitmaps, 8, 4, NpcInfo.IllustIndex);
+
             //布局 
             //水平排列
             int width = 0;
@@ -182,7 +185,110 @@ namespace WzComparerR2.CharaSimControl
                 DrawText(g, item, textRect.Location);
             }
             g.Dispose();
-            return bmp;
+            if (illustration2Tooltip != null)
+            {
+                Point illustration2Origin = new Point(bmp.Width, 0);
+                int totalWidth = bmp.Width + illustration2Tooltip.Width;
+                int totalHeight = Math.Max(bmp.Height, illustration2Tooltip.Height);
+                Bitmap newTooltip = new Bitmap(totalWidth, totalHeight, PixelFormat.Format32bppArgb);
+                Graphics g2 = Graphics.FromImage(newTooltip);
+                g2.DrawImage(bmp, 0, 0);
+                g2.DrawImage(illustration2Tooltip, illustration2Origin);
+                g2.Dispose();
+                return newTooltip;
+            }
+            else
+            {
+                return bmp;
+            }
+        }
+
+        private Bitmap drawIllustration2SetTooltip(List<Bitmap> bitmaps, int margin, int perLineCount, int npcIndex)
+        {
+            if (bitmaps == null || bitmaps.Count == 0)
+            {
+                return null;
+            }
+
+            if (ShowAllIllustAtOnce)
+            {
+                int requiredLines = (int)Math.Ceiling(bitmaps.Count / (double)perLineCount);
+
+                int width = 0;
+                int height = 0;
+
+                int currentLineWidth = 0;
+                int currentLineHeight = 0;
+                int lineCount = 0;
+                foreach (var bmp in bitmaps)
+                {
+                    if (bmp != null)
+                    {
+                        currentLineWidth += bmp.Width + margin;
+                        currentLineHeight = Math.Max(currentLineHeight, bmp.Height);
+                    }
+                    if (bitmaps.IndexOf(bmp) % perLineCount == perLineCount - 1)
+                    {
+                        width = Math.Max(width, currentLineWidth);
+                        height += currentLineHeight + margin;
+                        currentLineWidth = 0;
+                        currentLineHeight = 0;
+                        lineCount++;
+                    }
+                }
+                if (lineCount < requiredLines)
+                {
+                    width = Math.Max(width, currentLineWidth);
+                    height += currentLineHeight + margin;
+                    currentLineWidth = 0;
+                }
+                Bitmap result = new Bitmap(width + 30, height + 30, PixelFormat.Format32bppArgb);
+                using (Graphics g = Graphics.FromImage(result))
+                {
+                    GearGraphics.DrawNewTooltipBack(g, 0, 0, result.Width, result.Height);
+
+                    int x = 15;
+                    int y = 15;
+                    int maxLineHeight = 0;
+                    foreach (var bmp in bitmaps)
+                    {
+                        if (bmp != null)
+                        {
+                            maxLineHeight = Math.Max(maxLineHeight, bmp.Height);
+                            g.DrawImage(bmp, x, y + maxLineHeight - bmp.Height);
+                            x += bmp.Width + margin;
+                        }
+                        if (bitmaps.IndexOf(bmp) % perLineCount == perLineCount - 1)
+                        {
+                            x = 15;
+                            y += maxLineHeight + margin;
+                            maxLineHeight = 0;
+                        }
+                    }
+
+                    // Draw Illust Info
+                    int picH = 2;
+                    GearGraphics.DrawPlainText(g, $"일러스트: {bitmaps.Count}장", GearGraphics.ItemDetailFont, Color.FromArgb(255, 255, 255), 2, 80, ref picH, 13);
+                }
+                return result;
+            }
+            else
+            {
+                Bitmap targetIllust = bitmaps[npcIndex];
+                Bitmap result = new Bitmap(targetIllust.Width + 30, targetIllust.Height + 60, PixelFormat.Format32bppArgb);
+                using (Graphics g = Graphics.FromImage(result))
+                {
+                    GearGraphics.DrawNewTooltipBack(g, 0, 0, result.Width, result.Height);
+                    g.DrawImage(targetIllust, 15, 15);
+
+                    // Draw Illust Info
+                    int picH = 2;
+                    GearGraphics.DrawPlainText(g, $"일러스트: {npcIndex + 1} / {bitmaps.Count}", GearGraphics.ItemDetailFont, Color.FromArgb(255, 255, 255), 2, 130, ref picH, 13);
+                    picH += targetIllust.Height + 12;
+                    if (bitmaps.Count > 1) GearGraphics.DrawPlainText(g, $"전환하려면 [-]/[+]를 누릅니다.", GearGraphics.ItemDetailFont, Color.FromArgb(255, 255, 255), 12, 260, ref picH, 13);
+                }
+                return result;
+            }
         }
 
         private string GetNpcName(int npcID)

--- a/WzComparerR2/Comparer/EasyComparer.cs
+++ b/WzComparerR2/Comparer/EasyComparer.cs
@@ -1099,6 +1099,7 @@ namespace WzComparerR2.Comparer
                 tooltipRenderNewOld[i] = new NpcTooltipRenderer();
                 tooltipRenderNewOld[i].StringLinker = this.StringLinkerNewOld[i];
                 tooltipRenderNewOld[i].ShowObjectID = true;
+                tooltipRenderNewOld[i].ShowAllIllustAtOnce = true;
                 tooltipRenderNewOld[i].SourceWzFile = WzFileNewOld[i];
             }
 

--- a/WzComparerR2/Config/CharaSimNpcConfig.cs
+++ b/WzComparerR2/Config/CharaSimNpcConfig.cs
@@ -14,5 +14,12 @@ namespace WzComparerR2.Config
             get { return (bool)this["showID"]; }
             set { this["showID"] = value; }
         }
+
+        [ConfigurationProperty("showAllIllustAtOnce", DefaultValue = false)]
+        public bool ShowAllIllustAtOnce
+        {
+            get { return (bool)this["showAllIllustAtOnce"]; }
+            set { this["showAllIllustAtOnce"] = value; }
+        }
     }
 }

--- a/WzComparerR2/FrmQuickViewSetting.Designer.cs
+++ b/WzComparerR2/FrmQuickViewSetting.Designer.cs
@@ -31,6 +31,7 @@
             this.superTabControl1 = new DevComponents.DotNetBar.SuperTabControl();
             this.superTabControlPanel1 = new DevComponents.DotNetBar.SuperTabControlPanel();
             this.chkEnable22AniStyle = new DevComponents.DotNetBar.Controls.CheckBoxX();
+            this.chkShowAllIllustAtOnce = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkShowMiniMap = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkShowMiniMapMob = new DevComponents.DotNetBar.Controls.CheckBoxX();
             this.chkShowMiniMapNpc = new DevComponents.DotNetBar.Controls.CheckBoxX();
@@ -1097,6 +1098,7 @@
             // 
             // superTabControlPanel5
             // 
+            this.superTabControlPanel5.Controls.Add(this.chkShowAllIllustAtOnce);
             this.superTabControlPanel5.Controls.Add(this.chkEnable22AniStyle);
             this.superTabControlPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.superTabControlPanel5.Location = new System.Drawing.Point(62, 0);
@@ -1128,6 +1130,21 @@
             this.chkEnable22AniStyle.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
             this.chkEnable22AniStyle.TabIndex = 4;
             this.chkEnable22AniStyle.Text = "2025 UI 적용";
+            // 
+            // chkShowAllIllustAtOnce
+            // 
+            this.chkShowAllIllustAtOnce.AutoSize = true;
+            this.chkShowAllIllustAtOnce.BackColor = System.Drawing.Color.Transparent;
+            // 
+            // 
+            // 
+            this.chkShowAllIllustAtOnce.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square;
+            this.chkShowAllIllustAtOnce.Location = new System.Drawing.Point(13, 36);
+            this.chkShowAllIllustAtOnce.Name = "chkShowAllIllustAtOnce";
+            this.chkShowAllIllustAtOnce.Size = new System.Drawing.Size(145, 16);
+            this.chkShowAllIllustAtOnce.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled;
+            this.chkShowAllIllustAtOnce.TabIndex = 5;
+            this.chkShowAllIllustAtOnce.Text = "모든 NPC 일러스트를 한 번에 표시";
             // 
             // buttonX2
             // 
@@ -1252,6 +1269,7 @@
         private DevComponents.DotNetBar.LabelX labelCosmeticHairColor;
         private DevComponents.DotNetBar.LabelX labelCosmeticFaceColor;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkEnable22AniStyle;
+        private DevComponents.DotNetBar.Controls.CheckBoxX chkShowAllIllustAtOnce;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkinID;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkShowDamageSkin;
         private DevComponents.DotNetBar.Controls.CheckBoxX chkUseMiniSize;

--- a/WzComparerR2/FrmQuickViewSetting.cs
+++ b/WzComparerR2/FrmQuickViewSetting.cs
@@ -291,6 +291,13 @@ namespace WzComparerR2
         }
 
         [Link]
+        public bool Npc_ShowAllIllustAtOnce
+        {
+            get { return chkShowAllIllustAtOnce.Checked; }
+            set { chkShowAllIllustAtOnce.Checked = value; }
+        }
+
+        [Link]
         public int Quest_DefaultState
         {
             get { return comboBoxExQuestState.SelectedIndex; }

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -295,7 +295,7 @@ namespace WzComparerR2
             tooltipQuickView.MapRender.ShowMiniMapMob = Setting.Map.ShowMiniMapMob;
             tooltipQuickView.MapRender.ShowMiniMapNpc = Setting.Map.ShowMiniMapNpc;
             tooltipQuickView.MapRender.ShowMiniMapPortal = Setting.Map.ShowMiniMapPortal;
-
+            tooltipQuickView.NpcRender.ShowAllIllustAtOnce = Setting.Npc.ShowAllIllustAtOnce;
             tooltipQuickView.QuestRender.ShowObjectID = Setting.Quest.ShowID;
             tooltipQuickView.QuestRender.DefaultState = Setting.Quest.DefaultState;
             tooltipQuickView.QuestRender.ShowAllStates = Setting.Quest.ShowAllStates;
@@ -3790,6 +3790,26 @@ namespace WzComparerR2
                     case Keys.OemMinus:
                     case Keys.Subtract:
                         quest.State -= 1;
+                        frm.Refresh();
+                        return;
+                }
+            }
+
+
+            Npc npc = frm.TargetItem as Npc;
+            if (npc != null)
+            {
+                switch (e.KeyCode)
+                {
+                    case Keys.Oemplus:
+                    case Keys.Add:
+                        npc.IllustIndex += 1;
+                        frm.Refresh();
+                        return;
+
+                    case Keys.OemMinus:
+                    case Keys.Subtract:
+                        npc.IllustIndex -= 1;
                         frm.Refresh();
                         return;
                 }

--- a/WzComparerR2/MainForm.cs
+++ b/WzComparerR2/MainForm.cs
@@ -4255,7 +4255,7 @@ namespace WzComparerR2
 
                             // Initialize VCore Dictionary
                             Dictionary<int, List<int>> FifthJobSkillToJobID = new Dictionary<int, List<int>>();
-                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                            Wz_Node vCoreData = PluginManager.FindWz("Etc\\VcoreNew.img\\vSkill\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile()) ?? PluginManager.FindWz("Etc\\VCore.img\\CoreData", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
                             if (vCoreData != null)
                             {
                                 foreach (Wz_Node data in vCoreData.Nodes)
@@ -4293,7 +4293,7 @@ namespace WzComparerR2
                             tooltip.Enable22AniStyle = Setting.Misc.Enable22AniStyle;
                             foreach (var i in selectedJob)
                             {
-                                var jobImg = PluginManager.FindWz($"Skill\\{i:D3}.img\\skill", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                var jobImg = PluginManager.FindWz($"Skill\\{i:D3}.img\\skill");
                                 if (jobImg == null)
                                 {
                                     continue;
@@ -4344,7 +4344,7 @@ namespace WzComparerR2
                                     {
                                         if (kvp.Value.Contains(i))
                                         {
-                                            var skillNode = PluginManager.FindWz($"Skill\\{kvp.Key / 10000}.img\\skill\\{kvp.Key}", PluginManager.FindWz(Wz_Type.Base).GetNodeWzFile());
+                                            var skillNode = PluginManager.FindWz($"Skill\\{kvp.Key / 10000}.img\\skill\\{kvp.Key}");
                                             if (skillNode == null)
                                             {
                                                 continue;


### PR DESCRIPTION
As well as other upstream changes. However, save NPC Illust sample feature is not implemented yet.
<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/879a0d41-e560-4027-9c79-5665550e1b26" />
<img width="1630" height="923" alt="image" src="https://github.com/user-attachments/assets/c8204e23-94eb-4ca3-83ad-13f6380d0e5a" />

When doing WZ Compare, show all illust will be enabled when saving NPC Tooltips.