### PR TITLE
Add support for Kanna's new weapon

### DIFF
--- a/WzComparerR2.Common/CharaSim/Gear.cs
+++ b/WzComparerR2.Common/CharaSim/Gear.cs
@@ -558,6 +558,7 @@ namespace WzComparerR2.CharaSim
                 case 1215:
                 case 1252:
                 case 1253:
+                case 1254:
                 case 1259:
                 case 1403:
                 case 1404:

--- a/WzComparerR2.Common/CharaSim/GearType.cs
+++ b/WzComparerR2.Common/CharaSim/GearType.cs
@@ -181,6 +181,10 @@ namespace WzComparerR2.CharaSim
         /// </summary>
         celestialLight = 1253,
         /// <summary>
+        /// Onmyo Sen 1254
+        /// </summary>
+        onmyoSen = 1254,
+        /// <summary>
         /// 驯兽魔法棒 1259
         /// </summary>
         magicStick = 1259,
@@ -409,7 +413,11 @@ namespace WzComparerR2.CharaSim
         /// </summary>
         sacredJewel = 135404,
         /// <summary>
-        /// 手杖
+        /// Kanna Reifu 135430
+        /// </summary>
+        kannaReifu = 135430,
+        /// <summary>
+        /// 手杖 136
         /// </summary>
         cane = 136,
         /// <summary>

--- a/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
+++ b/WzComparerR2.Common/CharaSim/ItemStringHelper.cs
@@ -631,7 +631,7 @@ namespace WzComparerR2.CharaSim
                 case GearType.tamingChair: return "길들인 몬스터";
                 case GearType.saddle: return "안장";
                 case GearType.katana: return "카타나";
-                case GearType.fan: return "부채";
+                case GearType.fan: return "칸나 부채";
                 case GearType.swordZB: return "대검";
                 case GearType.swordZL: return "태도";
                 case GearType.weapon: return "무기";
@@ -713,6 +713,8 @@ namespace WzComparerR2.CharaSim
                 case GearType.authenticSymbol: return "어센틱심볼";
                 case GearType.grandAuthenticSymbol: return "그랜드 어센틱심볼";
 
+                case GearType.onmyoSen: return "음양 부채";
+                case GearType.kannaReifu: return "영부";
                 default: return null;
             }
         }
@@ -827,6 +829,8 @@ namespace WzComparerR2.CharaSim
                 case GearType.katana:
                 case GearType.kodachi:
                 case GearType.kodachi2: return "하야토 착용 가능";
+                case GearType.onmyoSen:
+                case GearType.kannaReifu:
                 case GearType.fan: return "칸나 착용 가능";
 
                 //5xxx


### PR DESCRIPTION
To distinguish Kanna's old fan from Ho Young's, Kanna's old fan is renamed to "칸나 부채".